### PR TITLE
Use EE RPA test email address for notifications

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function startServer() {
         teamName: 'Grants',
         teamEmail: 'grants@defra.gov.uk',
         submissionGuidance: "Thanks for your submission, we'll be in touch",
-        notificationEmail: 'noreply@defra.gov.uk',
+        notificationEmail: 'cl-defra-tactical-grants-test-rpa-email@equalexperts.com',
         createdBy: author,
         createdAt: now,
         updatedBy: author,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,8 @@ async function startServer() {
         teamName: 'Grants',
         teamEmail: 'grants@defra.gov.uk',
         submissionGuidance: "Thanks for your submission, we'll be in touch",
-        notificationEmail: 'cl-defra-tactical-grants-test-rpa-email@equalexperts.com',
+        notificationEmail:
+          'cl-defra-tactical-grants-test-rpa-email@equalexperts.com',
         createdBy: author,
         createdAt: now,
         updatedBy: author,


### PR DESCRIPTION
- Use the EE Tactical Grants test RPA email address for notifications
- This code is currently hard-coded but will be driven by config when finished