### PR TITLE
PLATFORM: Add support for page events, custom views and injectable controllers

### DIFF
--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -13,7 +13,8 @@ import { type RouteConfig } from '~/src/server/types.js'
 export const configureEnginePlugin = async ({
   formFileName,
   formFilePath,
-  services
+  services,
+  controllers
 }: RouteConfig = {}): Promise<ServerRegisterPluginObject<PluginOptions>> => {
   let model: FormModel | undefined
 
@@ -21,7 +22,7 @@ export const configureEnginePlugin = async ({
     const definition = await getForm(join(formFilePath, formFileName))
     const { name } = parse(formFileName)
 
-    model = new FormModel(definition, { basePath: name }, services)
+    model = new FormModel(definition, { basePath: name }, services, controllers)
   }
 
   return {

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -237,7 +237,8 @@ export class FormModel {
       payload: page.getFormDataFromState(request, state),
       state,
       paths: [],
-      isForceAccess
+      isForceAccess,
+      data: {}
     }
 
     // Validate current page

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -21,6 +21,7 @@ import {
   getPage
 } from '~/src/server/plugins/engine/helpers.js'
 import { type ExecutableCondition } from '~/src/server/plugins/engine/models/types.js'
+import { type PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import {
   createPage,
   type PageControllerClass
@@ -57,10 +58,13 @@ export class FormModel {
     version: string
   }
 
+  controllers?: Record<string, typeof PageController>
+
   constructor(
     def: typeof this.def,
     options: { basePath: string },
-    services: Services = defaultServices
+    services: Services = defaultServices,
+    controllers?: Record<string, typeof PageController>
   ) {
     const result = formDefinitionSchema.validate(def, { abortEarly: false })
 
@@ -103,6 +107,7 @@ export class FormModel {
       audience: 'human',
       version: '1'
     }
+    this.controllers = controllers
 
     def.conditions.forEach((conditionDef) => {
       const condition = this.makeCondition(conditionDef)

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -1,5 +1,6 @@
 import {
   ControllerPath,
+  type Events,
   type FormDefinition,
   type Page,
   type Section
@@ -41,6 +42,7 @@ export class PageController {
   title: string
   section?: Section
   condition?: ExecutableCondition
+  events?: Events
   collection?: ComponentCollection
   viewName = 'index'
 
@@ -52,6 +54,7 @@ export class PageController {
     this.model = model
     this.pageDef = pageDef
     this.title = pageDef.title
+    this.events = pageDef.events
 
     // Resolve section
     this.section = model.sections.find(
@@ -61,6 +64,11 @@ export class PageController {
     // Resolve condition
     if (pageDef.condition) {
       this.condition = model.conditions[pageDef.condition]
+    }
+
+    // Override view name
+    if (pageDef.view) {
+      this.viewName = pageDef.view
     }
   }
 

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -68,6 +68,7 @@ export function createPage(model: FormModel, pageDef: Page) {
   if (typeof controller === 'undefined') {
     if (model.controllers?.[pageDef.controller]) {
       const Ctrl = model.controllers[pageDef.controller]
+      // @ts-expect-error - TODO: Sort out the types so it understands that some controllers are custom/user provided
       controller = new Ctrl(model, pageDef)
     }
   }

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -66,6 +66,13 @@ export function createPage(model: FormModel, pageDef: Page) {
   }
 
   if (typeof controller === 'undefined') {
+    if (model.controllers?.[pageDef.controller]) {
+      const Ctrl = model.controllers[pageDef.controller]
+      controller = new Ctrl(model, pageDef)
+    }
+  }
+
+  if (typeof controller === 'undefined') {
     throw new Error(`Page controller ${pageDef.controller} does not exist`)
   }
 

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -40,6 +40,7 @@ import {
   pathSchema,
   stateSchema
 } from '~/src/server/schemas/index.js'
+import * as httpService from '~/src/server/services/httpService.js'
 import { type Services } from '~/src/server/types.js'
 
 export interface PluginOptions {
@@ -197,9 +198,26 @@ export const plugin = {
         return dispatchHandler(request, h)
       }
 
-      return redirectOrMakeHandler(request, h, (page, context) =>
-        page.makeGetRouteHandler()(request, context, h)
-      )
+      return redirectOrMakeHandler(request, h, async (page, context) => {
+        // Check for a page onLoad HTTP event and if one exists,
+        // call it and assign the response to the context data
+        const { events } = page
+
+        if (events?.onLoad && events.onLoad.type === 'http') {
+          const { options } = events.onLoad
+          const { url } = options
+
+          // TODO: Replace POST payload with structured data when helper
+          // is available from https://github.com/DEFRA/forms-runner/pull/679
+          const { payload } = await httpService.postJson(url, {
+            payload: context.relevantState
+          })
+
+          Object.assign(context.data, payload)
+        }
+
+        return page.makeGetRouteHandler()(request, context, h)
+      })
     }
 
     const postHandler = (

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -127,6 +127,11 @@ export interface FormContext {
 
   // Preview URL direct access is allowed
   isForceAccess: boolean
+
+  /**
+   * Miscellaneous extra data from event responses
+   */
+  data: object
 }
 
 export type FormContextRequest = (

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -7,6 +7,7 @@ import {
 
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { type DetailItem } from '~/src/server/plugins/engine/models/types.js'
+import { type PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import {
   type FormRequestPayload,
   type FormStatus
@@ -39,6 +40,7 @@ export interface RouteConfig {
   formFilePath?: string
   enforceCsrf?: boolean
   services?: Services
+  controllers?: Record<string, typeof PageController>
 }
 
 export interface OutputService {


### PR DESCRIPTION
Add support for:

- [Page events](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/478377) - initial support for page onLoad event 630d88005c6c4d9ddbd43adc5e04084c81b88e2c
- providing a custom view 630d88005c6c4d9ddbd43adc5e04084c81b88e2c
- injecting page controllers into the plugin - f7ae07d62b8d83376f018e1bbfd668728384188e

**NOTE:**
Before merging this back into the main repo, revisit the [TODO](https://github.com/DEFRA/forms-runner-v2/pull/13/files#diff-0024d0ac988316b31c66ea9c8492f938a754b56d96d598a03c7c84aad1a48dffR71) TS issue