### PR TITLE
PLATFORM: Pass controller through to FormModel

### DIFF
--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -27,7 +27,7 @@ export const configureEnginePlugin = async ({
 
   return {
     plugin,
-    options: { model, services }
+    options: { model, services, controllers }
   }
 }
 

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -22,6 +22,7 @@ import {
 } from '~/src/server/plugins/engine/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { FileUploadPageController } from '~/src/server/plugins/engine/pageControllers/FileUploadPageController.js'
+import { type PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { RepeatPageController } from '~/src/server/plugins/engine/pageControllers/RepeatPageController.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import * as defaultServices from '~/src/server/plugins/engine/services/index.js'
@@ -46,6 +47,7 @@ import { type Services } from '~/src/server/types.js'
 export interface PluginOptions {
   model?: FormModel
   services?: Services
+  controllers?: Record<string, typeof PageController>
 }
 
 export const plugin = {
@@ -53,7 +55,7 @@ export const plugin = {
   dependencies: '@hapi/vision',
   multiple: true,
   register(server, options) {
-    const { model, services = defaultServices } = options
+    const { model, services = defaultServices, controllers } = options
     const { formsService } = services
 
     server.app.model = model
@@ -126,7 +128,12 @@ export const plugin = {
           : slug
 
         // Construct the form model
-        const model = new FormModel(definition, { basePath }, services)
+        const model = new FormModel(
+          definition,
+          { basePath },
+          services,
+          controllers
+        )
 
         // Create new item and add it to the item cache
         item = { model, updatedAt: state.updatedAt }


### PR DESCRIPTION
Pass custom controllers into FormModel constructor when running in "services" mode (not just static file model).
Missed as part of https://github.com/DEFRA/forms-runner-v2/pull/13