### PR TITLE
PLATFORM: feature/templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "http-status-codes": "^2.3.0",
         "ioredis": "^5.4.2",
         "joi": "^17.13.3",
+        "liquidjs": "^10.20.3",
         "lodash": "^4.17.21",
         "marked": "^15.0.6",
         "nunjucks": "^3.2.3",
@@ -11561,6 +11562,35 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/liquidjs": {
+      "version": "10.20.3",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.20.3.tgz",
+      "integrity": "sha512-lSrPyIKT/ft0BJuZsz+QaWLclj4LY0v8X11K/VDTze4MrHGUedXSn3xuLL1MssBuaA49tNI+ZGI72fRpYSTLFg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
+    },
+    "node_modules/liquidjs/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/listr2": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "http-status-codes": "^2.3.0",
     "ioredis": "^5.4.2",
     "joi": "^17.13.3",
+    "liquidjs": "^10.20.3",
     "lodash": "^4.17.21",
     "marked": "^15.0.6",
     "nunjucks": "^3.2.3",

--- a/src/server/plugins/engine/README.md
+++ b/src/server/plugins/engine/README.md
@@ -15,6 +15,13 @@ The following elements support [LiquidJS templates](https://liquidjs.com/):
 - Html (guidance) component **content**
 - Summary component **row** key title (check answers and repeater summary)
 
+### Template data
+
+The data the templates are evaluated against is the raw answers the user has provided up to the page they're currently on.
+For example, given a YesNoField component called `TKsWbP`, the template `{{ TKsWbP }}` would render "true" or "false" depending on how the user answered the question.
+
+The current FormContext is also available as `context` in the templates. This allows access to the full data including the path the user has taken in their journey and any miscellaneous data returned from `Page event`s in `context.data`.
+
 ### Liquid Filters
 
 There are a number of `LiquidJS` filters available to you from within the templates:

--- a/src/server/plugins/engine/README.md
+++ b/src/server/plugins/engine/README.md
@@ -27,7 +27,6 @@ There are a number of `LiquidJS` filters available to you from within the templa
 ### Examples
 
 ```json
-...
 "pages": [
   {
     "title": "What's your name?",
@@ -36,13 +35,11 @@ There are a number of `LiquidJS` filters available to you from within the templa
       {
         "name": "WmHfSb",
         "title": "What's your full name?",
-        "type": "TextField",
-        "hint": "",
-        "options": {},
-        "schema": {}
+        "type": "TextField"
       }
     ]
   },
+  // This example shows how a component can use an answer to a previous question (What's your full name) in it's title
   {
     "title": "Are you in England?",
     "path": "/are-you-in-england",
@@ -50,19 +47,16 @@ There are a number of `LiquidJS` filters available to you from within the templa
       {
         "name": "TKsWbP",
         "title": "Are you in England, {{ WmHfSb }}?",
-        "type": "YesNoField",
-        "hint": "",
-        "options": {},
-        "schema": {}
+        "type": "YesNoField"
       }
     ]
   },
+  // This example shows how a Html (guidance) component can use the available filters to get the form definition and user answers and display them
   {
-    "title": "Information: In England? {{ TKsWbP }}?",
-    "path": "/information",
+    "title": "Template example for {{ WmHfSb }}?",
+    "path": "/example",
     "components": [
       {
-        "name": "Bcrhst",
         "title": "Html",
         "type": "Html",
         "content": "<p class=\"govuk-body\">
@@ -72,16 +66,14 @@ There are a number of `LiquidJS` filters available to you from within the templa
           // Use the reference to `evaluate` the title
           {{ inEngland.title | evaluate }}<br>
 
-          // Use the href filter to display the page path
+          // Use the href filter to display the full page path
           {{ \"/are-you-in-england\" | href }}<br>
 
           // Use the `answer` filter to render the user provided answer to a question
           {{ 'TKsWbP' | answer }}
-        </p>\n",
-        "options": {},
-        "schema": {}
+        </p>\n"
       }
     ]
   }
-],...
+]
 ```

--- a/src/server/plugins/engine/README.md
+++ b/src/server/plugins/engine/README.md
@@ -1,0 +1,89 @@
+# forms-engine
+
+Form hapi-plugin
+
+...
+
+## Templates
+
+The following elements support [LiquidJS templates](https://liquidjs.com/):
+
+- Page **title**
+- Form component **titles**
+  - Support for fieldset legend text or label text
+  - This includes when the title is used in **error messages**
+- Html (guidance) component **content**
+
+### Liquid Filters
+
+There are a number of `LiquidJS` filters available to you from within the templates:
+
+- `page` - returns the page for the given path
+- `pagedef` - returns the page definition for the given path
+- `field` - returns the component field for the given name
+- `fielddef` - returns the component field definition for the given name
+- `href` - returns the page href for the given page
+- `answer` - returns the users answer for a given component field
+- `evaluate` - evaluates and returns a Liquid template
+
+### Examples
+
+```json
+...
+"pages": [
+  {
+    "title": "What's your name?",
+    "path": "/full-name",
+    "components": [
+      {
+        "name": "WmHfSb",
+        "title": "What's your full name?",
+        "type": "TextField",
+        "hint": "",
+        "options": {},
+        "schema": {}
+      }
+    ]
+  },
+  {
+    "title": "Are you in England?",
+    "path": "/are-you-in-england",
+    "components": [
+      {
+        "name": "TKsWbP",
+        "title": "Are you in England, {{ WmHfSb }}?",
+        "type": "YesNoField",
+        "hint": "",
+        "options": {},
+        "schema": {}
+      }
+    ]
+  },
+  {
+    "title": "Information: In England? {{ TKsWbP }}?",
+    "path": "/information",
+    "components": [
+      {
+        "name": "Bcrhst",
+        "title": "Html",
+        "type": "Html",
+        "content": "<p class=\"govuk-body\">
+          // Use Liquid's `assign` to create a variable that holds reference to the \"/are-you-in-england\" page
+          {%- assign inEngland = \"/are-you-in-england\" | page -%}
+
+          // Use the reference to `evaluate` the title
+          {{ inEngland.title | evaluate }}<br>
+
+          // and to display the page href
+          {{ inEngland | href }}<br>
+
+          // Use the `answer` filter to render the user provided answer to a question
+          {{ 'TKsWbP' | answer }}
+        </p>\n",
+        "options": {},
+        "schema": {}
+      }
+    ]
+  }
+],...
+```

--- a/src/server/plugins/engine/README.md
+++ b/src/server/plugins/engine/README.md
@@ -18,13 +18,11 @@ The following elements support [LiquidJS templates](https://liquidjs.com/):
 
 There are a number of `LiquidJS` filters available to you from within the templates:
 
-- `page` - returns the page for the given path
-- `pagedef` - returns the page definition for the given path
-- `field` - returns the component field for the given name
-- `fielddef` - returns the component field definition for the given name
-- `href` - returns the page href for the given page
-- `answer` - returns the users answer for a given component field
-- `evaluate` - evaluates and returns a Liquid template
+- `page` - returns the page definition for the given path
+- `field` - returns the component definition for the given name
+- `href` - returns the page href for the given page path
+- `answer` - returns the user's answer for a given component
+- `evaluate` - evaluates and returns a Liquid template using the current context
 
 ### Examples
 
@@ -74,8 +72,8 @@ There are a number of `LiquidJS` filters available to you from within the templa
           // Use the reference to `evaluate` the title
           {{ inEngland.title | evaluate }}<br>
 
-          // and to display the page href
-          {{ inEngland | href }}<br>
+          // Use the href filter to display the page path
+          {{ \"/are-you-in-england\" | href }}<br>
 
           // Use the `answer` filter to render the user provided answer to a question
           {{ 'TKsWbP' | answer }}

--- a/src/server/plugins/engine/README.md
+++ b/src/server/plugins/engine/README.md
@@ -13,6 +13,7 @@ The following elements support [LiquidJS templates](https://liquidjs.com/):
   - Support for fieldset legend text or label text
   - This includes when the title is used in **error messages**
 - Html (guidance) component **content**
+- Summary component **row** key title (check answers and repeater summary)
 
 ### Liquid Filters
 

--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -76,7 +76,7 @@ describe.each([
         expect(keys).toHaveProperty(
           'myComponent',
           expect.objectContaining({
-            flags: expect.objectContaining({ label: def.title.toLowerCase() })
+            flags: expect.objectContaining({ label: def.title })
           })
         )
       })

--- a/src/server/plugins/engine/components/CheckboxesField.test.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.test.ts
@@ -79,7 +79,7 @@ describe.each([
         expect(keys).toHaveProperty(
           'myComponent',
           expect.objectContaining({
-            flags: expect.objectContaining({ label: def.title.toLowerCase() })
+            flags: expect.objectContaining({ label: def.title })
           })
         )
       })
@@ -157,7 +157,7 @@ describe.each([
               {
                 allow: options.allow,
                 flags: {
-                  label: def.title.toLowerCase(),
+                  label: def.title,
                   only: true
                 },
                 type: options.list.type

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -30,13 +30,9 @@ export class CheckboxesField extends SelectionControlField {
 
     const itemsSchema = joi[type]()
       .valid(...this.values)
-      .label(title.toLowerCase())
+      .label(title)
 
-    formSchema = formSchema
-      .items(itemsSchema)
-      .single()
-      .label(title.toLowerCase())
-      .required()
+    formSchema = formSchema.items(itemsSchema).single().label(title).required()
 
     if (options.required === false) {
       formSchema = formSchema.optional()

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -114,7 +114,7 @@ export class ComponentCollection {
 
         // Update error with child label
         if (child && (!error.local.label || error.local.label === 'value')) {
-          error.local.label = child.title.toLowerCase()
+          error.local.label = child.title
         }
 
         // Fix error summary links for missing fields

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -48,21 +48,21 @@ describe('DatePartsField', () => {
         expect(keys).toHaveProperty(
           'myComponent__day',
           expect.objectContaining({
-            flags: expect.objectContaining({ label: 'day' })
+            flags: expect.objectContaining({ label: 'Day' })
           })
         )
 
         expect(keys).toHaveProperty(
           'myComponent__month',
           expect.objectContaining({
-            flags: expect.objectContaining({ label: 'month' })
+            flags: expect.objectContaining({ label: 'Month' })
           })
         )
 
         expect(keys).toHaveProperty(
           'myComponent__year',
           expect.objectContaining({
-            flags: expect.objectContaining({ label: 'year' })
+            flags: expect.objectContaining({ label: 'Year' })
           })
         )
       })

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -47,7 +47,7 @@ describe('EmailAddressField', () => {
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: 'example email address field'
+              label: 'Example email address field'
             })
           })
         )

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -18,12 +18,7 @@ export class EmailAddressField extends FormComponent {
 
     const { options, title } = def
 
-    let formSchema = joi
-      .string()
-      .email()
-      .trim()
-      .label(title.toLowerCase())
-      .required()
+    let formSchema = joi.string().email().trim().label(title).required()
 
     if (options.required === false) {
       formSchema = formSchema.allow('')

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -177,7 +177,7 @@ describe('FileUploadField', () => {
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: 'example file upload field'
+              label: 'Example file upload field'
             })
           })
         )

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -106,11 +106,7 @@ export class FileUploadField extends FormComponent {
 
     const { options, schema, title } = def
 
-    let formSchema = joi
-      .array<FileState>()
-      .label(title.toLowerCase())
-      .single()
-      .required()
+    let formSchema = joi.array<FileState>().label(title).single().required()
 
     if (options.required === false) {
       formSchema = formSchema.optional()

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -71,7 +71,7 @@ export class ListFormComponent extends FormComponent {
 
     let formSchema = joi[this.listType]()
       .valid(...this.values)
-      .label(title.toLowerCase())
+      .label(title)
       .required()
 
     if (options.customValidationMessages) {

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -48,10 +48,10 @@ describe('MonthYearField', () => {
         expect(keys).toEqual(
           expect.objectContaining({
             myComponent__month: expect.objectContaining({
-              flags: expect.objectContaining({ label: 'month' })
+              flags: expect.objectContaining({ label: 'Month' })
             }),
             myComponent__year: expect.objectContaining({
-              flags: expect.objectContaining({ label: 'year' })
+              flags: expect.objectContaining({ label: 'Year' })
             })
           })
         )

--- a/src/server/plugins/engine/components/MultilineTextField.test.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.test.ts
@@ -49,7 +49,7 @@ describe('MultilineTextField', () => {
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: 'example textarea'
+              label: 'Example textarea'
             })
           })
         )

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -24,7 +24,7 @@ export class MultilineTextField extends FormComponent {
 
     const { schema, options, title } = def
 
-    let formSchema = Joi.string().trim().label(title.toLowerCase()).required()
+    let formSchema = Joi.string().trim().label(title).required()
 
     if (options.required === false) {
       formSchema = formSchema.allow('')

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -46,7 +46,7 @@ describe('NumberField', () => {
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: 'example number field'
+              label: 'Example number field'
             })
           })
         )

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -31,7 +31,7 @@ export class NumberField extends FormComponent {
     let formSchema = joi
       .number()
       .custom(getValidatorPrecision(this))
-      .label(title.toLowerCase())
+      .label(title)
       .required()
 
     if (options.required === false) {

--- a/src/server/plugins/engine/components/RadiosField.test.ts
+++ b/src/server/plugins/engine/components/RadiosField.test.ts
@@ -74,7 +74,7 @@ describe.each([
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: def.title.toLowerCase()
+              label: def.title
             })
           })
         )

--- a/src/server/plugins/engine/components/SelectField.test.ts
+++ b/src/server/plugins/engine/components/SelectField.test.ts
@@ -74,7 +74,7 @@ describe.each([
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: def.title.toLowerCase()
+              label: def.title
             })
           })
         )

--- a/src/server/plugins/engine/components/TelephoneNumberField.test.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.test.ts
@@ -47,7 +47,7 @@ describe('TelephoneNumberField', () => {
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: 'example telephone number field'
+              label: 'Example telephone number field'
             })
           })
         )

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -27,7 +27,7 @@ export class TelephoneNumberField extends FormComponent {
       .string()
       .trim()
       .pattern(PATTERN)
-      .label(title.toLowerCase())
+      .label(title)
       .required()
 
     if (options.required === false) {

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -45,7 +45,7 @@ describe('TextField', () => {
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: 'example text field'
+              label: 'Example text field'
             })
           })
         )

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -33,7 +33,7 @@ export class TextField extends FormComponent {
     const { options, title } = def
     const schema = 'schema' in def ? def.schema : {}
 
-    let formSchema = joi.string().trim().label(title.toLowerCase()).required()
+    let formSchema = joi.string().trim().label(title).required()
 
     if (options.required === false) {
       formSchema = formSchema.allow('')

--- a/src/server/plugins/engine/components/UkAddressField.test.ts
+++ b/src/server/plugins/engine/components/UkAddressField.test.ts
@@ -47,28 +47,28 @@ describe('UkAddressField', () => {
         expect(keys).toHaveProperty(
           'myComponent__addressLine1',
           expect.objectContaining({
-            flags: expect.objectContaining({ label: 'address line 1' })
+            flags: expect.objectContaining({ label: 'Address line 1' })
           })
         )
 
         expect(keys).toHaveProperty(
           'myComponent__addressLine2',
           expect.objectContaining({
-            flags: expect.objectContaining({ label: 'address line 2' })
+            flags: expect.objectContaining({ label: 'Address line 2' })
           })
         )
 
         expect(keys).toHaveProperty(
           'myComponent__town',
           expect.objectContaining({
-            flags: expect.objectContaining({ label: 'town or city' })
+            flags: expect.objectContaining({ label: 'Town or city' })
           })
         )
 
         expect(keys).toHaveProperty(
           `myComponent__postcode`,
           expect.objectContaining({
-            flags: expect.objectContaining({ label: 'postcode' })
+            flags: expect.objectContaining({ label: 'Postcode' })
           })
         )
       })

--- a/src/server/plugins/engine/components/YesNoField.test.ts
+++ b/src/server/plugins/engine/components/YesNoField.test.ts
@@ -41,7 +41,7 @@ describe('YesNoField', () => {
         'myComponent',
         expect.objectContaining({
           flags: expect.objectContaining({
-            label: 'example yes/no'
+            label: 'Example yes/no'
           })
         })
       )

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -515,7 +515,6 @@ describe('Helpers', () => {
         paths: [],
         isForceAccess: false,
         data: {},
-        model,
         pageDefMap: model.pageDefMap,
         listDefMap: model.listDefMap,
         componentDefMap: model.componentDefMap,
@@ -549,46 +548,11 @@ describe('Helpers', () => {
       expect(result).toBe('Hello, Enrique Chase!')
     })
 
-    it('page filter should return the page', () => {
+    it('page filter should return the page definition', () => {
       // @ts-expect-error - spyOn type issue
       const filterSpy = jest.spyOn(engine.filters, 'page')
       const result = evaluateTemplate(
-        '{%- assign inEnglandPage = "/are-you-in-england" | page -%}{{ inEnglandPage.path }}',
-        formContext
-      )
-
-      expect(filterSpy).toHaveBeenCalledWith('/are-you-in-england')
-      expect(result).toBe('/are-you-in-england')
-    })
-
-    it('page filter should return empty when anything but a string is passed', () => {
-      // @ts-expect-error - spyOn type issue
-      const filterSpy = jest.spyOn(engine.filters, 'page')
-
-      let result = evaluateTemplate('{{ 0 | page }}', formContext)
-      expect(filterSpy).toHaveBeenLastCalledWith(0)
-      expect(result).toBe('')
-
-      result = evaluateTemplate('{{ undefined | page }}', formContext)
-      expect(filterSpy).toHaveBeenLastCalledWith(undefined)
-      expect(result).toBe('')
-
-      result = evaluateTemplate('{{ null | page }}', formContext)
-      expect(result).toBe('')
-
-      result = evaluateTemplate('{{ false | page }}', formContext)
-      expect(filterSpy).toHaveBeenLastCalledWith(false)
-      expect(result).toBe('')
-
-      result = evaluateTemplate('{{ [] | page }}', formContext)
-      expect(result).toBe('')
-    })
-
-    it('pagedef filter should return the page definition', () => {
-      // @ts-expect-error - spyOn type issue
-      const filterSpy = jest.spyOn(engine.filters, 'pagedef')
-      const result = evaluateTemplate(
-        '{%- assign startPageDef = "/start" | pagedef -%}{{ startPageDef.title }}',
+        '{%- assign startPageDef = "/start" | page -%}{{ startPageDef.title }}',
         formContext
       )
 
@@ -596,38 +560,35 @@ describe('Helpers', () => {
       expect(result).toBe('Start page')
     })
 
-    it('pagedef filter should return empty when anything but a string is passed', () => {
+    it('page filter should return empty when anything but a string is passed', () => {
       // @ts-expect-error - spyOn type issue
-      const pageFilterSpy = jest.spyOn(engine.filters, 'pagedef')
+      const pageFilterSpy = jest.spyOn(engine.filters, 'page')
 
-      let result = evaluateTemplate('{{ 0 | pagedef }}', formContext)
+      let result = evaluateTemplate('{{ 0 | page }}', formContext)
       expect(pageFilterSpy).toHaveBeenLastCalledWith(0)
       expect(result).toBe('')
 
-      result = evaluateTemplate('{{ undefined | pagedef }}', formContext)
+      result = evaluateTemplate('{{ undefined | page }}', formContext)
       expect(pageFilterSpy).toHaveBeenLastCalledWith(undefined)
       expect(result).toBe('')
 
-      result = evaluateTemplate('{{ null | pagedef }}', formContext)
+      result = evaluateTemplate('{{ null | page }}', formContext)
       expect(result).toBe('')
 
-      result = evaluateTemplate('{{ false | pagedef }}', formContext)
+      result = evaluateTemplate('{{ false | page }}', formContext)
       expect(pageFilterSpy).toHaveBeenLastCalledWith(false)
       expect(result).toBe('')
 
-      result = evaluateTemplate('{{ [] | pagedef }}', formContext)
+      result = evaluateTemplate('{{ [] | page }}', formContext)
       expect(result).toBe('')
     })
 
     it('href filter should return the page href', () => {
       // @ts-expect-error - spyOn type issue
       const filterSpy = jest.spyOn(engine.filters, 'href')
-      const result = evaluateTemplate(
-        '{{ "/full-name" | page | href }}',
-        formContext
-      )
+      const result = evaluateTemplate('{{ "/full-name" | href }}', formContext)
 
-      expect(filterSpy).toHaveBeenCalledWith(model.pageMap.get('/full-name'))
+      expect(filterSpy).toHaveBeenCalledWith('/full-name')
       expect(result).toBe('/template/full-name')
     })
 
@@ -640,46 +601,11 @@ describe('Helpers', () => {
       expect(result).toBe('')
     })
 
-    it('field filter should return the component', () => {
+    it('field filter should return the component definition', () => {
       // @ts-expect-error - spyOn type issue
       const filterSpy = jest.spyOn(engine.filters, 'field')
       const result = evaluateTemplate(
-        '{%- assign inEnglandComponent = "TKsWbP" | field -%}{{ inEnglandComponent.type }}',
-        formContext
-      )
-
-      expect(filterSpy).toHaveBeenCalledWith('TKsWbP')
-      expect(result).toBe('YesNoField')
-    })
-
-    it('field filter should return empty when anything but a string is passed', () => {
-      // @ts-expect-error - spyOn type issue
-      const filterSpy = jest.spyOn(engine.filters, 'field')
-
-      let result = evaluateTemplate('{{ 0 | field }}', formContext)
-      expect(filterSpy).toHaveBeenLastCalledWith(0)
-      expect(result).toBe('')
-
-      result = evaluateTemplate('{{ undefined | field }}', formContext)
-      expect(filterSpy).toHaveBeenLastCalledWith(undefined)
-      expect(result).toBe('')
-
-      result = evaluateTemplate('{{ null | field }}', formContext)
-      expect(result).toBe('')
-
-      result = evaluateTemplate('{{ false | field }}', formContext)
-      expect(filterSpy).toHaveBeenLastCalledWith(false)
-      expect(result).toBe('')
-
-      result = evaluateTemplate('{{ [] | field }}', formContext)
-      expect(result).toBe('')
-    })
-
-    it('fielddef filter should return the component definition', () => {
-      // @ts-expect-error - spyOn type issue
-      const filterSpy = jest.spyOn(engine.filters, 'fielddef')
-      const result = evaluateTemplate(
-        '{%- assign fullNameComponentDef = "WmHfSb" | fielddef -%}{{ fullNameComponentDef.title }}',
+        '{%- assign fullNameComponentDef = "WmHfSb" | field -%}{{ fullNameComponentDef.title }}',
         formContext
       )
 
@@ -687,26 +613,26 @@ describe('Helpers', () => {
       expect(result).toBe('What&#39;s your full name?')
     })
 
-    it('fielddef filter should return empty when anything but a string is passed', () => {
+    it('field filter should return empty when anything but a string is passed', () => {
       // @ts-expect-error - spyOn type issue
-      const pageFilterSpy = jest.spyOn(engine.filters, 'fielddef')
+      const pageFilterSpy = jest.spyOn(engine.filters, 'field')
 
-      let result = evaluateTemplate('{{ 0 | fielddef }}', formContext)
+      let result = evaluateTemplate('{{ 0 | field }}', formContext)
       expect(pageFilterSpy).toHaveBeenLastCalledWith(0)
       expect(result).toBe('')
 
-      result = evaluateTemplate('{{ undefined | fielddef }}', formContext)
+      result = evaluateTemplate('{{ undefined | field }}', formContext)
       expect(pageFilterSpy).toHaveBeenLastCalledWith(undefined)
       expect(result).toBe('')
 
-      result = evaluateTemplate('{{ null | fielddef }}', formContext)
+      result = evaluateTemplate('{{ null | field }}', formContext)
       expect(result).toBe('')
 
-      result = evaluateTemplate('{{ false | fielddef }}', formContext)
+      result = evaluateTemplate('{{ false | field }}', formContext)
       expect(pageFilterSpy).toHaveBeenLastCalledWith(false)
       expect(result).toBe('')
 
-      result = evaluateTemplate('{{ [] | fielddef }}', formContext)
+      result = evaluateTemplate('{{ [] | field }}', formContext)
       expect(result).toBe('')
     })
 

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -389,7 +389,7 @@ describe('Helpers', () => {
       ])
     })
 
-    it('formats first letter to uppercase', () => {
+    it('does not format the first letter to uppercase', () => {
       const { details } = new ValidationError(
         'Date of marriage example',
         [
@@ -410,7 +410,7 @@ describe('Helpers', () => {
           path: ['yesNoField'],
           href: '#yesNoField',
           name: 'yesNoField',
-          text: 'Something invalid',
+          text: 'something invalid',
           context: {
             key: 'yesNoField'
           }

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -8,6 +8,8 @@ import {
   checkEmailAddressForLiveFormSubmission,
   checkFormStatus,
   encodeUrl,
+  engine,
+  evaluateTemplate,
   getErrors,
   getPageHref,
   proceed,
@@ -18,13 +20,17 @@ import {
   createPage,
   type PageControllerClass
 } from '~/src/server/plugins/engine/pageControllers/helpers.js'
-import { type FormContextRequest } from '~/src/server/plugins/engine/types.js'
+import {
+  type FormContext,
+  type FormContextRequest
+} from '~/src/server/plugins/engine/types.js'
 import {
   FormAction,
   FormStatus,
   type FormRequest
 } from '~/src/server/routes/types.js'
 import definition from '~/test/form/definitions/basic.js'
+import templateDefinition from '~/test/form/definitions/templates.js'
 
 describe('Helpers', () => {
   let page: PageControllerClass
@@ -488,6 +494,270 @@ describe('Helpers', () => {
       expect(validRequest.server.plugins.crumb.generate).toHaveBeenCalledWith(
         validRequest
       )
+    })
+  })
+
+  describe('evaluateTemplate', () => {
+    let model: FormModel
+    let formContext: FormContext
+
+    beforeEach(() => {
+      model = new FormModel(templateDefinition, {
+        basePath: 'template'
+      })
+
+      formContext = {
+        evaluationState: {},
+        relevantState: {},
+        relevantPages: [],
+        payload: {},
+        state: {},
+        paths: [],
+        isForceAccess: false,
+        data: {},
+        model,
+        pageDefMap: model.pageDefMap,
+        listDefMap: model.listDefMap,
+        componentDefMap: model.componentDefMap,
+        pageMap: model.pageMap,
+        componentMap: model.componentMap
+      }
+    })
+
+    it('should replace placeholders with values from form context relevantState', () => {
+      Object.assign(formContext.relevantState, {
+        WmHfSb: 'Enrique Chase'
+      })
+
+      const areYouInEngland = templateDefinition.pages[2]
+      expect(areYouInEngland.title).toBe('Are you in England, {{ WmHfSb }}?')
+
+      const result = evaluateTemplate(areYouInEngland.title, formContext)
+      expect(result).toBe('Are you in England, Enrique Chase?')
+    })
+
+    it('evaluate filter should evaluate a liquid template', () => {
+      Object.assign(formContext.relevantState, {
+        WmHfSb: 'Enrique Chase'
+      })
+
+      const result = evaluateTemplate(
+        '{{ "Hello, {{ WmHfSb }}!" | evaluate }}',
+        formContext
+      )
+
+      expect(result).toBe('Hello, Enrique Chase!')
+    })
+
+    it('page filter should return the page', () => {
+      // @ts-expect-error - spyOn type issue
+      const filterSpy = jest.spyOn(engine.filters, 'page')
+      const result = evaluateTemplate(
+        '{%- assign inEnglandPage = "/are-you-in-england" | page -%}{{ inEnglandPage.path }}',
+        formContext
+      )
+
+      expect(filterSpy).toHaveBeenCalledWith('/are-you-in-england')
+      expect(result).toBe('/are-you-in-england')
+    })
+
+    it('page filter should return empty when anything but a string is passed', () => {
+      // @ts-expect-error - spyOn type issue
+      const filterSpy = jest.spyOn(engine.filters, 'page')
+
+      let result = evaluateTemplate('{{ 0 | page }}', formContext)
+      expect(filterSpy).toHaveBeenLastCalledWith(0)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ undefined | page }}', formContext)
+      expect(filterSpy).toHaveBeenLastCalledWith(undefined)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ null | page }}', formContext)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ false | page }}', formContext)
+      expect(filterSpy).toHaveBeenLastCalledWith(false)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ [] | page }}', formContext)
+      expect(result).toBe('')
+    })
+
+    it('pagedef filter should return the page definition', () => {
+      // @ts-expect-error - spyOn type issue
+      const filterSpy = jest.spyOn(engine.filters, 'pagedef')
+      const result = evaluateTemplate(
+        '{%- assign startPageDef = "/start" | pagedef -%}{{ startPageDef.title }}',
+        formContext
+      )
+
+      expect(filterSpy).toHaveBeenCalledWith('/start')
+      expect(result).toBe('Start page')
+    })
+
+    it('pagedef filter should return empty when anything but a string is passed', () => {
+      // @ts-expect-error - spyOn type issue
+      const pageFilterSpy = jest.spyOn(engine.filters, 'pagedef')
+
+      let result = evaluateTemplate('{{ 0 | pagedef }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(0)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ undefined | pagedef }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(undefined)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ null | pagedef }}', formContext)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ false | pagedef }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(false)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ [] | pagedef }}', formContext)
+      expect(result).toBe('')
+    })
+
+    it('href filter should return the page href', () => {
+      // @ts-expect-error - spyOn type issue
+      const filterSpy = jest.spyOn(engine.filters, 'href')
+      const result = evaluateTemplate(
+        '{{ "/full-name" | page | href }}',
+        formContext
+      )
+
+      expect(filterSpy).toHaveBeenCalledWith(model.pageMap.get('/full-name'))
+      expect(result).toBe('/template/full-name')
+    })
+
+    it('href filter should return empty when no page passed', () => {
+      // @ts-expect-error - spyOn type issue
+      const pageFilterSpy = jest.spyOn(engine.filters, 'href')
+
+      const result = evaluateTemplate('{{ undefined | href }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(undefined)
+      expect(result).toBe('')
+    })
+
+    it('field filter should return the component', () => {
+      // @ts-expect-error - spyOn type issue
+      const filterSpy = jest.spyOn(engine.filters, 'field')
+      const result = evaluateTemplate(
+        '{%- assign inEnglandComponent = "TKsWbP" | field -%}{{ inEnglandComponent.type }}',
+        formContext
+      )
+
+      expect(filterSpy).toHaveBeenCalledWith('TKsWbP')
+      expect(result).toBe('YesNoField')
+    })
+
+    it('field filter should return empty when anything but a string is passed', () => {
+      // @ts-expect-error - spyOn type issue
+      const filterSpy = jest.spyOn(engine.filters, 'field')
+
+      let result = evaluateTemplate('{{ 0 | field }}', formContext)
+      expect(filterSpy).toHaveBeenLastCalledWith(0)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ undefined | field }}', formContext)
+      expect(filterSpy).toHaveBeenLastCalledWith(undefined)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ null | field }}', formContext)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ false | field }}', formContext)
+      expect(filterSpy).toHaveBeenLastCalledWith(false)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ [] | field }}', formContext)
+      expect(result).toBe('')
+    })
+
+    it('fielddef filter should return the component definition', () => {
+      // @ts-expect-error - spyOn type issue
+      const filterSpy = jest.spyOn(engine.filters, 'fielddef')
+      const result = evaluateTemplate(
+        '{%- assign fullNameComponentDef = "WmHfSb" | fielddef -%}{{ fullNameComponentDef.title }}',
+        formContext
+      )
+
+      expect(filterSpy).toHaveBeenCalledWith('WmHfSb')
+      expect(result).toBe('What&#39;s your full name?')
+    })
+
+    it('fielddef filter should return empty when anything but a string is passed', () => {
+      // @ts-expect-error - spyOn type issue
+      const pageFilterSpy = jest.spyOn(engine.filters, 'fielddef')
+
+      let result = evaluateTemplate('{{ 0 | fielddef }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(0)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ undefined | fielddef }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(undefined)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ null | fielddef }}', formContext)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ false | fielddef }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(false)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ [] | fielddef }}', formContext)
+      expect(result).toBe('')
+    })
+
+    it('answer filter should return the formatted submitted answer', () => {
+      Object.assign(formContext.relevantState, {
+        TKsWbP: true,
+        WmHfSb: 'Enrique Chase'
+      })
+
+      // @ts-expect-error - spyOn type issue
+      const filterSpy = jest.spyOn(engine.filters, 'answer')
+
+      let result = evaluateTemplate("{{ 'TKsWbP' | answer }}", formContext)
+      expect(filterSpy).toHaveBeenCalledWith('TKsWbP')
+      expect(result).toBe('Yes')
+
+      result = evaluateTemplate("{{ 'WmHfSb' | answer }}", formContext)
+      expect(filterSpy).toHaveBeenCalledWith('WmHfSb')
+      expect(result).toBe('Enrique Chase')
+    })
+
+    it('answer filter should return empty when anything but a string is passed', () => {
+      // @ts-expect-error - spyOn type issue
+      const pageFilterSpy = jest.spyOn(engine.filters, 'answer')
+
+      let result = evaluateTemplate('{{ 0 | answer }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(0)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ undefined | answer }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(undefined)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ null | answer }}', formContext)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ false | answer }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith(false)
+      expect(result).toBe('')
+
+      result = evaluateTemplate('{{ [] | answer }}', formContext)
+      expect(result).toBe('')
+    })
+
+    it('answer filter should return empty when non-form component name is passed', () => {
+      // @ts-expect-error - spyOn type issue
+      const pageFilterSpy = jest.spyOn(engine.filters, 'answer')
+
+      const result = evaluateTemplate('{{ "FGyiLS" | answer }}', formContext)
+      expect(pageFilterSpy).toHaveBeenLastCalledWith('FGyiLS')
+      expect(result).toBe('')
     })
   })
 })

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -535,6 +535,19 @@ describe('Helpers', () => {
       expect(result).toBe('Are you in England, Enrique Chase?')
     })
 
+    it('should replace placeholders with values from form context data', () => {
+      Object.assign(formContext.data, {
+        score: 'Low'
+      })
+
+      const result = evaluateTemplate(
+        'Your score is: {{ context.data.score }}',
+        formContext
+      )
+
+      expect(result).toBe('Your score is: Low')
+    })
+
     it('evaluate filter should evaluate a liquid template', () => {
       Object.assign(formContext.relevantState, {
         WmHfSb: 'Enrique Chase'

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -83,7 +83,7 @@ engine.registerFilter('href', function (path: string, query?: FormQuery) {
   return getPageHref(page, query)
 })
 
-engine.registerFilter('field', function (name) {
+engine.registerFilter('field', function (name: string) {
   if (typeof name !== 'string') {
     return
   }
@@ -94,7 +94,7 @@ engine.registerFilter('field', function (name) {
   return componentDef
 })
 
-engine.registerFilter('answer', function (name) {
+engine.registerFilter('answer', function (name: string) {
   if (typeof name !== 'string') {
     return
   }

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -8,7 +8,11 @@ import { Liquid } from 'liquidjs'
 
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
-import { getAnswer } from '~/src/server/plugins/engine/components/helpers.js'
+import {
+  getAnswer,
+  type Component,
+  type Field
+} from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
@@ -31,46 +35,91 @@ const engine = new Liquid({
   jsTruthy: true
 })
 
-engine.registerFilter('evaluate', function (template) {
-  const evaluated = evaluateTemplate(template, this.context.globals.context)
+interface GlobalScope {
+  context: FormContext
+  pages: Map<string, PageControllerClass>
+  components: Map<string, Component>
+}
+
+engine.registerFilter('evaluate', function (template?: string) {
+  if (typeof template !== 'string') {
+    return template
+  }
+
+  const globals = this.context.globals as GlobalScope
+  const evaluated = evaluateTemplate(template, globals.context)
 
   return evaluated
 })
 
-engine.registerFilter('page', function (path) {
-  const page = this.context.globals.pages.get(path)
+engine.registerFilter('page', function (path?: string) {
+  if (typeof path !== 'string') {
+    return
+  }
+
+  const globals = this.context.globals as GlobalScope
+  const page = globals.pages.get(path)
 
   return page
 })
 
-engine.registerFilter('pagedef', function (path) {
-  const pageDef = this.context.globals.context.pageDefMap.get(path)
+engine.registerFilter('pagedef', function (path?: string) {
+  if (typeof path !== 'string') {
+    return
+  }
+
+  const globals = this.context.globals as GlobalScope
+  const pageDef = globals.context.pageDefMap.get(path)
 
   return pageDef
 })
 
 engine.registerFilter(
   'href',
-  function (page: PageControllerClass, query?: FormQuery) {
+  function (page?: PageControllerClass, query?: FormQuery) {
+    if (page === undefined) {
+      return
+    }
+
     return getPageHref(page, query)
   }
 )
 
-engine.registerFilter('field', function (name) {
-  const component = this.context.globals.components.get(name)
+engine.registerFilter('field', function (name?: string) {
+  if (typeof name !== 'string') {
+    return
+  }
+
+  const globals = this.context.globals as GlobalScope
+  const component = globals.components.get(name)
 
   return component
 })
 
 engine.registerFilter('fielddef', function (name) {
-  const componentDef = this.context.globals.context.componentDefMap.get(name)
+  if (typeof name !== 'string') {
+    return
+  }
+
+  const globals = this.context.globals as GlobalScope
+  const componentDef = globals.context.componentDefMap.get(name)
 
   return componentDef
 })
 
 engine.registerFilter('answer', function (name) {
-  const component = this.context.globals.components.get(name)
-  const answer = getAnswer(component, this.context.globals.context.state)
+  if (typeof name !== 'string') {
+    return
+  }
+
+  const globals = this.context.globals as GlobalScope
+  const component = globals.components.get(name)
+
+  if (!component?.isFormComponent) {
+    return
+  }
+
+  const answer = getAnswer(component as Field, globals.context.state)
 
   return answer
 })
@@ -319,8 +368,14 @@ export function evaluateTemplate(
   context: FormContext
 ): string {
   const { model } = context
+  const globals: GlobalScope = {
+    context,
+    pages: model.pageMap,
+    components: model.componentMap
+  }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return engine.parseAndRenderSync(template, context.evaluationState, {
-    globals: { context, pages: model.pageMap, components: model.componentMap }
+    globals
   })
 }

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -30,9 +30,10 @@ import {
 
 const logger = createLogger()
 
-const engine = new Liquid({
+export const engine = new Liquid({
   outputEscape: 'escape',
-  jsTruthy: true
+  jsTruthy: true,
+  ownPropertyOnly: false
 })
 
 interface GlobalScope {
@@ -119,7 +120,7 @@ engine.registerFilter('answer', function (name) {
     return
   }
 
-  const answer = getAnswer(component as Field, globals.context.state)
+  const answer = getAnswer(component as Field, globals.context.relevantState)
 
   return answer
 })
@@ -375,7 +376,7 @@ export function evaluateTemplate(
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return engine.parseAndRenderSync(template, context.evaluationState, {
+  return engine.parseAndRenderSync(template, context.relevantState, {
     globals
   })
 }

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -264,7 +264,6 @@ export class FormModel {
       paths: [],
       isForceAccess,
       data: {},
-      model: this,
       pageDefMap: this.pageDefMap,
       listDefMap: this.listDefMap,
       componentDefMap: this.componentDefMap,

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -4,17 +4,21 @@ import {
   ControllerType,
   Engine,
   formDefinitionSchema,
+  hasComponents,
   hasRepeater,
+  type ComponentDef,
   type ConditionWrapper,
   type ConditionsModelData,
   type DateUnits,
   type FormDefinition,
-  type List
+  type List,
+  type Page
 } from '@defra/forms-model'
 import { add } from 'date-fns'
 import { Parser, type Value } from 'expr-eval'
 import joi from 'joi'
 
+import { type Component } from '~/src/server/plugins/engine/components/helpers.js'
 import {
   findPage,
   getError,
@@ -55,6 +59,11 @@ export class FormModel {
   services: Services
 
   controllers?: Record<string, typeof PageController>
+  pageDefMap: Map<string, Page>
+  listDefMap: Map<string, List>
+  componentDefMap: Map<string, ComponentDef>
+  pageMap: Map<string, PageControllerClass>
+  componentMap: Map<string, Component>
 
   constructor(
     def: typeof this.def,
@@ -122,6 +131,26 @@ export class FormModel {
         })
       )
     }
+
+    this.pageDefMap = new Map(def.pages.map((page) => [page.path, page]))
+    this.listDefMap = new Map(def.lists.map((list) => [list.name, list]))
+    this.componentDefMap = new Map(
+      def.pages
+        .filter(hasComponents)
+        .flatMap((page) =>
+          page.components.map((component) => [component.name, component])
+        )
+    )
+
+    this.pageMap = new Map(this.pages.map((page) => [page.path, page]))
+    this.componentMap = new Map(
+      this.pages.flatMap((page) =>
+        page.collection.components.map((component) => [
+          component.name,
+          component
+        ])
+      )
+    )
   }
 
   /**
@@ -234,7 +263,13 @@ export class FormModel {
       state,
       paths: [],
       isForceAccess,
-      data: {}
+      data: {},
+      model: this,
+      pageDefMap: this.pageDefMap,
+      listDefMap: this.listDefMap,
+      componentDefMap: this.componentDefMap,
+      pageMap: this.pageMap,
+      componentMap: this.componentMap
     }
 
     // Validate current page

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -5,7 +5,11 @@ import {
   type Field
 } from '~/src/server/plugins/engine/components/helpers.js'
 import { type BackLink } from '~/src/server/plugins/engine/components/types.js'
-import { getError, getPageHref } from '~/src/server/plugins/engine/helpers.js'
+import {
+  evaluateTemplate,
+  getError,
+  getPageHref
+} from '~/src/server/plugins/engine/helpers.js'
 import {
   type Detail,
   type DetailItem,
@@ -87,7 +91,7 @@ export class SummaryViewModel {
 
         return {
           key: {
-            text: item.title
+            text: evaluateTemplate(item.title, context)
           },
           value: {
             classes: 'app-prose-scope',

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
@@ -62,7 +62,7 @@ describe('FileUploadPageController', () => {
           text: 'Select upload something',
           context: {
             key: 'fileUpload',
-            label: 'upload something',
+            label: 'Upload something',
             title: 'Upload something'
           }
         }

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
@@ -228,7 +228,7 @@ describe('RepeatPageController', () => {
           text: 'Select toppings',
           context: {
             key: 'toppings',
-            label: 'toppings',
+            label: 'Toppings',
             title: 'Toppings'
           }
         },
@@ -239,7 +239,7 @@ describe('RepeatPageController', () => {
           text: 'Enter quantity',
           context: {
             key: 'quantity',
-            label: 'quantity',
+            label: 'Quantity',
             title: 'Quantity'
           }
         },

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -3,9 +3,7 @@ import lowerFirst from 'lodash/lowerFirst.js'
 
 const opts = {
   functions: {
-    lowerFirst: (val: string) => {
-      return lowerFirst(val)
-    }
+    lowerFirst
   }
 }
 
@@ -31,7 +29,10 @@ export const messageTemplate = {
 
   // Nested fields use component title
   objectRequired: joi.expression('Enter {{#label}}', opts),
-  objectMissing: joi.expression('{{#title}} must include a {{#label}}', opts),
+  objectMissing: joi.expression(
+    '{{#title}} must include a {{lowerFirst(#label)}}',
+    opts
+  ),
   dateFormat: '{{#title}} must be a real date',
   dateMin: '{{#title}} must be the same as or after {{#limit}}',
   dateMax: '{{#title}} must be the same as or before {{#limit}}'

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -1,15 +1,27 @@
-import { type LanguageMessages, type ValidationOptions } from 'joi'
+import joi, { type LanguageMessages, type ValidationOptions } from 'joi'
+import lowerFirst from 'lodash/lowerFirst.js'
+
+const opts = {
+  functions: {
+    lowerFirst: (val: string) => {
+      return lowerFirst(val)
+    }
+  }
+}
 
 /**
  * see @link https://joi.dev/api/?v=17.4.2#template-syntax for template syntax
  */
 export const messageTemplate = {
-  required: 'Enter {{#label}}',
-  selectRequired: 'Select {{#label}}',
+  required: joi.expression('Enter {{lowerFirst(#label)}}', opts),
+  selectRequired: joi.expression('Select {{lowerFirst(#label)}}', opts),
   max: '{{#label}} must be {{#limit}} characters or less',
   min: '{{#label}} must be {{#limit}} characters or more',
-  pattern: 'Enter a valid {{#label}}',
-  format: 'Enter {{#label}} in the correct format',
+  pattern: joi.expression('Enter a valid {{lowerFirst(#label)}}', opts),
+  format: joi.expression(
+    'Enter {{lowerFirst(#label)}} in the correct format',
+    opts
+  ),
   number: '{{#label}} must be a number',
   numberPrecision: '{{#label}} must have {{#limit}} or fewer decimal places',
   numberInteger: '{{#label}} must be a whole number',
@@ -18,8 +30,8 @@ export const messageTemplate = {
   maxWords: '{{#label}} must be {{#limit}} words or fewer',
 
   // Nested fields use component title
-  objectRequired: 'Enter {{#label}}',
-  objectMissing: '{{#title}} must include a {{#label}}',
+  objectRequired: joi.expression('Enter {{#label}}', opts),
+  objectMissing: joi.expression('{{#title}} must include a {{#label}}', opts),
   dateFormat: '{{#title}} must be a real date',
   dateMin: '{{#title}} must be the same as or after {{#limit}}',
   dateMax: '{{#title}} must be the same as or before {{#limit}}'

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+// Declaration above is needed for: https://github.com/hapijs/joi/issues/3064
+
 import joi, { type LanguageMessages, type ValidationOptions } from 'joi'
 import lowerFirst from 'lodash/lowerFirst.js'
 
@@ -11,13 +14,17 @@ const opts = {
  * see @link https://joi.dev/api/?v=17.4.2#template-syntax for template syntax
  */
 export const messageTemplate = {
+  // @ts-expect-error - joi.expression options type issue
   required: joi.expression('Enter {{lowerFirst(#label)}}', opts),
+  // @ts-expect-error - joi.expression options type issue
   selectRequired: joi.expression('Select {{lowerFirst(#label)}}', opts),
   max: '{{#label}} must be {{#limit}} characters or less',
   min: '{{#label}} must be {{#limit}} characters or more',
+  // @ts-expect-error - joi.expression options type issue
   pattern: joi.expression('Enter a valid {{lowerFirst(#label)}}', opts),
   format: joi.expression(
     'Enter {{lowerFirst(#label)}} in the correct format',
+    // @ts-expect-error - joi.expression options type issue
     opts
   ),
   number: '{{#label}} must be a number',
@@ -28,9 +35,12 @@ export const messageTemplate = {
   maxWords: '{{#label}} must be {{#limit}} words or fewer',
 
   // Nested fields use component title
+
+  // @ts-expect-error - joi.expression options type issue
   objectRequired: joi.expression('Enter {{#label}}', opts),
   objectMissing: joi.expression(
     '{{#title}} must include a {{lowerFirst(#label)}}',
+    // @ts-expect-error - joi.expression options type issue
     opts
   ),
   dateFormat: '{{#title}} must be a real date',

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -13,7 +13,6 @@ import {
   type ComponentText,
   type ComponentViewModel
 } from '~/src/server/plugins/engine/components/types.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { type PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import { type ViewContext } from '~/src/server/plugins/nunjucks/types.js'
@@ -141,12 +140,6 @@ export interface FormContext {
    * Miscellaneous extra data from event responses
    */
   data: object
-
-  /**
-   * The form model
-   * {@link FormModel}
-   */
-  model: FormModel
 
   pageDefMap: Map<string, Page>
   listDefMap: Map<string, List>

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -1,12 +1,19 @@
-import { type Item } from '@defra/forms-model'
+import {
+  type ComponentDef,
+  type Item,
+  type List,
+  type Page
+} from '@defra/forms-model'
 import { type ValidationErrorItem } from 'joi'
 
-import { type FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
+import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
+import { type Component } from '~/src/server/plugins/engine/components/helpers.js'
 import {
   type BackLink,
   type ComponentText,
   type ComponentViewModel
 } from '~/src/server/plugins/engine/components/types.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { type PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import { type ViewContext } from '~/src/server/plugins/nunjucks/types.js'
@@ -125,13 +132,27 @@ export interface FormContext {
    */
   paths: string[]
 
-  // Preview URL direct access is allowed
+  /**
+   * Preview URL direct access is allowed
+   */
   isForceAccess: boolean
 
   /**
    * Miscellaneous extra data from event responses
    */
   data: object
+
+  /**
+   * The form model
+   * {@link FormModel}
+   */
+  model: FormModel
+
+  pageDefMap: Map<string, Page>
+  listDefMap: Map<string, List>
+  componentDefMap: Map<string, ComponentDef>
+  pageMap: Map<string, PageControllerClass>
+  componentMap: Map<string, Component>
 }
 
 export type FormContextRequest = (

--- a/src/server/plugins/engine/views/index.html
+++ b/src/server/plugins/engine/views/index.html
@@ -13,7 +13,7 @@
       {% if errors %}
         {{ govukErrorSummary({
           titleText: "There is a problem",
-          errorList: errors
+          errorList: checkErrorTemplates(errors)
         }) }}
       {% endif %}
 

--- a/src/server/plugins/engine/views/partials/components.html
+++ b/src/server/plugins/engine/views/partials/components.html
@@ -1,6 +1,6 @@
 {% macro componentList(components) %}
   {% for component in components %}
     {% import "../components/" + component.type.toLowerCase() + ".html" as view with context %}
-    {{ view[component.type](component) }}
+    {{ view[component.type](checkComponentTemplates(component)) }}
   {% endfor %}
 {% endmacro %}

--- a/src/server/plugins/engine/views/partials/heading.html
+++ b/src/server/plugins/engine/views/partials/heading.html
@@ -1,9 +1,9 @@
 {% if sectionTitle and (sectionTitle !== pageTitle) or itemTitle %}
   <h2 class="govuk-caption-l govuk-!-margin-top-0" id="section-title">
     {% if sectionTitle and itemTitle %}
-      {{- sectionTitle }}: {{ itemTitle -}}
+      {{- sectionTitle }}: {{ evaluate(itemTitle) -}}
     {% elif not sectionTitle %}
-      {{- itemTitle -}}
+      {{- evaluate(itemTitle) -}}
     {% else %}
       {{- sectionTitle -}}
     {% endif %}
@@ -11,6 +11,6 @@
 {% endif %}
 {% if showTitle %}
   <h1 class="govuk-heading-l">
-    {{ pageTitle }}
+    {{ evaluate(pageTitle) }}
   </h1>
 {% endif %}

--- a/src/server/plugins/nunjucks/environment.js
+++ b/src/server/plugins/nunjucks/environment.js
@@ -66,6 +66,7 @@ function checkComponentTemplates(component) {
     // Evaluate label/legend text
     if (component.model.fieldset?.legend?.text) {
       const legend = component.model.fieldset.legend
+
       legend.text = evaluateTemplate(legend.text, context)
     } else if (component.model.label?.text) {
       const label = component.model.label
@@ -81,6 +82,7 @@ function checkComponentTemplates(component) {
     }
   } else if (component.type === ComponentType.Html) {
     const content = component.model.content
+
     if (typeof content === 'string') {
       component.model.content = evaluateTemplate(content, context)
     }

--- a/src/server/plugins/nunjucks/environment.js
+++ b/src/server/plugins/nunjucks/environment.js
@@ -1,9 +1,11 @@
 import { dirname, join } from 'node:path'
 
+import { ComponentType } from '@defra/forms-model'
 import nunjucks from 'nunjucks'
 import resolvePkg from 'resolve'
 
 import { config } from '~/src/config/index.js'
+import { evaluateTemplate } from '~/src/server/plugins/engine/helpers.js'
 import * as filters from '~/src/server/plugins/nunjucks/filters/index.js'
 
 const govukFrontendPath = dirname(
@@ -28,3 +30,69 @@ export const environment = nunjucks.configure(
 for (const [name, nunjucksFilter] of Object.entries(filters)) {
   environment.addFilter(name, nunjucksFilter)
 }
+
+/**
+ * @param {FormSubmissionError[]} errors
+ */
+function checkErrorTemplates(errors) {
+  const { context } = this.ctx
+
+  errors.forEach(error => {
+    error.text = evaluateTemplate(error.text, context)
+  })
+
+  return errors
+}
+
+environment.addGlobal('checkErrorTemplates', checkErrorTemplates)
+
+/**
+ * @param {ComponentViewModel} component
+ */
+function checkComponentTemplates(component) {
+  const { context } = this.ctx
+
+  if (component.isFormComponent) {
+    // Evaluate label/legend text
+    if (component.model.fieldset?.legend?.text) {
+      const legend = component.model.fieldset.legend
+      legend.text = evaluateTemplate(legend.text, context)
+    } else if (component.model.label?.text) {
+      const label = component.model.label
+
+      label.text = evaluateTemplate(label.text, context)
+    }
+
+    // Evaluate error message
+    if (component.model.errorMessage?.text) {
+      const message = component.model.errorMessage
+
+      message.text = evaluateTemplate(message.text, context)
+    }
+  } else if (component.type === ComponentType.Html) {
+    const content = component.model.content
+    if (typeof content === 'string') {
+      component.model.content = evaluateTemplate(content, context)
+    }
+  }
+
+  return component
+}
+
+environment.addGlobal('checkComponentTemplates', checkComponentTemplates)
+
+/**
+ * @param {string} template
+ */
+function evaluate(template) {
+  const { context } = this.ctx
+
+  return evaluateTemplate(template, context)
+}
+
+environment.addGlobal('evaluate', evaluate)
+
+/**
+ * @import { FormSubmissionError } from '~/src/server/plugins/engine/types.js'
+ * @import { ComponentViewModel } from '~/src/server/plugins/engine/components/types.js'
+ */

--- a/src/server/plugins/nunjucks/environment.js
+++ b/src/server/plugins/nunjucks/environment.js
@@ -32,12 +32,17 @@ for (const [name, nunjucksFilter] of Object.entries(filters)) {
 }
 
 /**
+ * @this {NunjucksContext}
  * @param {FormSubmissionError[]} errors
  */
 function checkErrorTemplates(errors) {
   const { context } = this.ctx
 
-  errors.forEach(error => {
+  if (!context) {
+    return errors
+  }
+
+  errors.forEach((error) => {
     error.text = evaluateTemplate(error.text, context)
   })
 
@@ -47,10 +52,15 @@ function checkErrorTemplates(errors) {
 environment.addGlobal('checkErrorTemplates', checkErrorTemplates)
 
 /**
+ * @this {NunjucksContext}
  * @param {ComponentViewModel} component
  */
 function checkComponentTemplates(component) {
   const { context } = this.ctx
+
+  if (!context) {
+    return component
+  }
 
   if (component.isFormComponent) {
     // Evaluate label/legend text
@@ -82,17 +92,19 @@ function checkComponentTemplates(component) {
 environment.addGlobal('checkComponentTemplates', checkComponentTemplates)
 
 /**
+ * @this {NunjucksContext}
  * @param {string} template
  */
 function evaluate(template) {
   const { context } = this.ctx
 
-  return evaluateTemplate(template, context)
+  return context ? evaluateTemplate(template, context) : template
 }
 
 environment.addGlobal('evaluate', evaluate)
 
 /**
+ * @import { NunjucksContext } from '~/src/server/plugins/nunjucks/types.js'
  * @import { FormSubmissionError } from '~/src/server/plugins/engine/types.js'
  * @import { ComponentViewModel } from '~/src/server/plugins/engine/components/types.js'
  */

--- a/src/server/plugins/nunjucks/filters/evaluate.js
+++ b/src/server/plugins/nunjucks/filters/evaluate.js
@@ -1,0 +1,10 @@
+import { evaluateTemplate } from '~/src/server/plugins/engine/helpers.js'
+
+/**
+ * @param {string} template
+ */
+export function evaluate(template) {
+  const { context } = this.ctx
+
+  return evaluateTemplate(template, context)
+}

--- a/src/server/plugins/nunjucks/filters/evaluate.js
+++ b/src/server/plugins/nunjucks/filters/evaluate.js
@@ -1,10 +1,19 @@
 import { evaluateTemplate } from '~/src/server/plugins/engine/helpers.js'
 
 /**
+ * @this {NunjucksContext}
  * @param {string} template
  */
 export function evaluate(template) {
   const { context } = this.ctx
 
+  if (!context) {
+    return template
+  }
+
   return evaluateTemplate(template, context)
 }
+
+/**
+ * @import { NunjucksContext } from '~/src/server/plugins/nunjucks/types.js'
+ */

--- a/src/server/plugins/nunjucks/filters/evaluate.js
+++ b/src/server/plugins/nunjucks/filters/evaluate.js
@@ -1,13 +1,15 @@
 import { evaluateTemplate } from '~/src/server/plugins/engine/helpers.js'
 
 /**
+ * Nunjucks filter to evaluate a liquid template.
+ * Current just used in `src/server/views/layout.html#LN37` for the pageTitle
  * @this {NunjucksContext}
  * @param {string} template
  */
 export function evaluate(template) {
   const { context } = this.ctx
 
-  if (!context) {
+  if (!context || typeof template !== 'string') {
     return template
   }
 

--- a/src/server/plugins/nunjucks/filters/index.js
+++ b/src/server/plugins/nunjucks/filters/index.js
@@ -1,3 +1,4 @@
 export { markdownToHtml as markdown } from '@defra/forms-model'
 export { highlight } from '~/src/server/plugins/nunjucks/filters/highlight.js'
 export { inspect } from '~/src/server/plugins/nunjucks/filters/inspect.js'
+export { evaluate } from '~/src/server/plugins/nunjucks/filters/evaluate.js'

--- a/src/server/plugins/nunjucks/types.js
+++ b/src/server/plugins/nunjucks/types.js
@@ -21,6 +21,7 @@
  * @property {string} [previewMode] - Preview mode
  * @property {string} [slug] - Form slug
  * @property {(asset?: string) => string} getAssetPath - Asset path resolver
+ * @property {FormContext} [context] - the current form context
  */
 
 /**
@@ -28,6 +29,12 @@
  */
 
 /**
+ * @typedef NunjucksContext
+ * @property {ViewContext} ctx - the current nunjucks view context
+ */
+
+/**
  * @import { CookieConsent } from '~/src/common/types.js'
  * @import { config } from '~/src/config/index.js'
+ * @import { FormContext } from '~/src/server/plugins/engine/types.js'
  */

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block pageTitle -%}
-  {{ "Error: " if errors | length }}{{ pageTitle }} - {{ name if name else config.serviceName }} - GOV.UK
+  {{ "Error: " if errors | length }}{{ pageTitle | evaluate }} - {{ name if name else config.serviceName }} - GOV.UK
 {%- endblock %}
 
 {% block skipLink %}

--- a/test/form/definitions/templates.js
+++ b/test/form/definitions/templates.js
@@ -6,7 +6,7 @@ import {
 } from '@defra/forms-model'
 
 export default /** @satisfies {FormDefinition} */ ({
-  name: 'Grants',
+  name: 'Templates',
   pages: [
     {
       title: 'Start page',
@@ -115,7 +115,7 @@ export default /** @satisfies {FormDefinition} */ ({
           title: 'Html',
           type: ComponentType.Html,
           content:
-            '<p class="govuk-body">Welcome to Grants.{%- assign inEngland = "/are-you-in-england" | page -%}{{ inEngland.title | evaluate }}<br>{{ \'TKsWbP\' | answer }}<br>{{ inEngland | href }}</p>\n',
+            '<p class="govuk-body">Welcome to Templates.{%- assign inEngland = "/are-you-in-england" | page -%}<span data-testid="output-1">{{ inEngland.title | evaluate }}</span><br><span data-testid="output-2">{{ \'sdFYHf\' | answer }}</span><br><span data-testid="output-3">{{ \'TKsWbP\' | answer }}</span><br><span data-testid="output-4">{{ inEngland.path | href }}</span></p>\n',
           options: {}
         }
       ]

--- a/test/form/definitions/templates.js
+++ b/test/form/definitions/templates.js
@@ -1,0 +1,183 @@
+import {
+  ComponentType,
+  ConditionType,
+  ControllerType,
+  OperatorName
+} from '@defra/forms-model'
+
+export default /** @satisfies {FormDefinition} */ ({
+  name: 'Grants',
+  pages: [
+    {
+      title: 'Start page',
+      path: '/start',
+      controller: ControllerType.Start,
+      components: [
+        {
+          name: 'Jhimsh',
+          title: 'Html',
+          type: ComponentType.Html,
+          content: '<p class="govuk-body">Welcome to templating.</p>\n',
+          options: {}
+        }
+      ],
+      next: [
+        {
+          path: '/full-name'
+        }
+      ]
+    },
+    {
+      title: "What's your name?",
+      path: '/full-name',
+      next: [
+        {
+          path: '/are-you-in-england'
+        }
+      ],
+      components: [
+        {
+          name: 'WmHfSb',
+          title: "What's your full name?",
+          type: ComponentType.TextField,
+          hint: '',
+          options: {},
+          schema: {}
+        }
+      ]
+    },
+    {
+      title: 'Are you in England, {{ WmHfSb }}?',
+      path: '/are-you-in-england',
+      next: [
+        {
+          path: '/you-must-be-in-england',
+          condition: 'uFOrmA'
+        },
+        {
+          path: '/what-is-your-business'
+        }
+      ],
+      components: [
+        {
+          name: 'TKsWbP',
+          title: 'Are you in England, {{ WmHfSb }}?',
+          type: ComponentType.YesNoField,
+          hint: '',
+          options: {}
+        }
+      ]
+    },
+    {
+      title: 'You must be in England',
+      path: '/you-must-be-in-england',
+      next: [],
+      components: [
+        {
+          name: 'FGyiLS',
+          title: 'You must be in England',
+          type: ComponentType.Html,
+          content: '<p class="govuk-body">You must be in England.</p>\n',
+          options: {}
+        }
+      ]
+    },
+    {
+      title: 'What is your business, {{ WmHfSb }}?',
+      path: '/what-is-your-business',
+      next: [
+        {
+          path: '/information'
+        }
+      ],
+      components: [
+        {
+          name: 'sdFYHf',
+          title: 'What is your business, {{ WmHfSb }}?',
+          type: ComponentType.RadiosField,
+          list: 'dfdGFY',
+          hint: '',
+          options: {}
+        }
+      ]
+    },
+    {
+      title: 'Information: In England? {{ TKsWbP }}?',
+      path: '/information',
+      next: [
+        {
+          path: '/summary'
+        }
+      ],
+      components: [
+        {
+          name: 'Bcrhst',
+          title: 'Html',
+          type: ComponentType.Html,
+          content:
+            '<p class="govuk-body">Welcome to Grants.{%- assign inEngland = "/are-you-in-england" | page -%}{{ inEngland.title | evaluate }}<br>{{ \'TKsWbP\' | answer }}<br>{{ inEngland | href }}</p>\n',
+          options: {}
+        }
+      ]
+    },
+    {
+      path: '/summary',
+      controller: ControllerType.Summary,
+      title: 'Check your answers before submitting your form'
+    }
+  ],
+  lists: [
+    {
+      title: 'What is the nature of your business?',
+      name: 'dfdGFY',
+      type: 'string',
+      items: [
+        {
+          text: 'A grower or producer of agricultural or horticultural produce',
+          description: 'For example, arable or livestock farmer',
+          value: 'grower'
+        },
+        {
+          text: 'A business processing agricultural or horticultural products',
+          description:
+            'For example a cheese processing business owner by farmer',
+          value: 'business'
+        },
+        {
+          text: 'None of the above',
+          value: 'none'
+        }
+      ]
+    }
+  ],
+  sections: [],
+  conditions: [
+    {
+      name: 'uFOrmA',
+      displayName: 'notEngland',
+      value: {
+        name: 'notEngland',
+        conditions: [
+          {
+            field: {
+              name: 'TKsWbP',
+              type: ComponentType.YesNoField,
+              display: 'Are you in England?'
+            },
+            operator: OperatorName.Is,
+            value: {
+              type: ConditionType.Value,
+              value: 'false',
+              display: 'No'
+            }
+          }
+        ]
+      }
+    }
+  ],
+  startPage: '/start'
+})
+
+/**
+ * @import { FormDefinition } from '@defra/forms-model'
+ */

--- a/test/form/template.test.js
+++ b/test/form/template.test.js
@@ -1,0 +1,259 @@
+import { join } from 'node:path'
+
+import { within } from '@testing-library/dom'
+import { StatusCodes } from 'http-status-codes'
+
+import { createServer } from '~/src/server/index.js'
+import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
+import * as fixtures from '~/test/fixtures/index.js'
+import { renderResponse } from '~/test/helpers/component-helpers.js'
+import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
+
+const basePath = '/templates'
+
+jest.mock('~/src/server/plugins/engine/services/formsService.js')
+
+describe('Form template journey', () => {
+  /** @type {Server} */
+  let server
+
+  /** @type {string} */
+  let csrfToken
+
+  /** @type {ReturnType<typeof getCookieHeader>} */
+  let headers
+
+  // Create server before each test
+  beforeAll(async () => {
+    server = await createServer({
+      formFileName: 'templates.js',
+      formFilePath: join(import.meta.dirname, 'definitions'),
+      enforceCsrf: true
+    })
+
+    await server.initialize()
+
+    // Navigate to start
+    const response = await server.inject({
+      url: `${basePath}/start`
+    })
+
+    // Extract the session cookie
+    csrfToken = getCookie(response, 'crumb')
+    headers = getCookieHeader(response, ['session', 'crumb'])
+  })
+
+  beforeEach(() => {
+    jest.mocked(getFormMetadata).mockResolvedValue(fixtures.form.metadata)
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  test('GET /start', async () => {
+    const { container, response } = await renderResponse(server, {
+      url: `${basePath}/start`,
+      headers
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const $heading = container.getByRole('heading', {
+      name: 'Start page',
+      level: 1
+    })
+
+    expect($heading).toBeInTheDocument()
+  })
+
+  test('GET /full-name', async () => {
+    const { container, response } = await renderResponse(server, {
+      url: `${basePath}/full-name`,
+      headers
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const $heading = container.getByRole('heading', {
+      name: "What's your name?",
+      level: 1
+    })
+
+    expect($heading).toBeInTheDocument()
+  })
+
+  test('POST /full-name', async () => {
+    const { response } = await renderResponse(server, {
+      url: `${basePath}/full-name`,
+      method: 'POST',
+      headers,
+      payload: { WmHfSb: 'Enrique Chase', crumb: csrfToken }
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(response.headers.location).toBe(`${basePath}/are-you-in-england`)
+  })
+
+  test('GET /are-you-in-england', async () => {
+    const { container, response } = await renderResponse(server, {
+      url: `${basePath}/are-you-in-england`,
+      headers
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const $title = await container.findByText(
+      'Are you in England, Enrique Chase? - Templates - GOV.UK'
+    )
+
+    expect($title).toBeInTheDocument()
+
+    const $heading = container.getByRole('heading', {
+      name: 'Are you in England, Enrique Chase?',
+      level: 1
+    })
+
+    expect($heading).toBeInTheDocument()
+  })
+
+  test('POST /are-you-in-england with empty payload', async () => {
+    const { response, container } = await renderResponse(server, {
+      url: `${basePath}/are-you-in-england`,
+      method: 'POST',
+      headers,
+      payload: { crumb: csrfToken }
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const $errorSummary = container.getByRole('alert')
+
+    const $heading = within($errorSummary).getByRole('heading', {
+      name: 'There is a problem',
+      level: 2
+    })
+
+    expect($heading).toBeInTheDocument()
+
+    const $errorItems = within($errorSummary).getAllByRole('listitem')
+    expect($errorItems[0]).toHaveTextContent(
+      'Select are you in England, Enrique Chase?'
+    )
+  })
+
+  test('POST /are-you-in-england', async () => {
+    const { response } = await renderResponse(server, {
+      url: `${basePath}/are-you-in-england`,
+      method: 'POST',
+      headers,
+      payload: { TKsWbP: 'true', crumb: csrfToken }
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(response.headers.location).toBe(`${basePath}/what-is-your-business`)
+  })
+
+  test('GET /what-is-your-business', async () => {
+    const { container, response } = await renderResponse(server, {
+      url: `${basePath}/what-is-your-business`,
+      headers
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const $title = await container.findByText(
+      'What is your business, Enrique Chase? - Templates - GOV.UK'
+    )
+
+    expect($title).toBeInTheDocument()
+
+    const $heading = container.getByRole('heading', {
+      name: 'What is your business, Enrique Chase?',
+      level: 1
+    })
+
+    expect($heading).toBeInTheDocument()
+  })
+
+  test('POST /what-is-your-business with empty payload', async () => {
+    const { response, container } = await renderResponse(server, {
+      url: `${basePath}/what-is-your-business`,
+      method: 'POST',
+      headers,
+      payload: { crumb: csrfToken }
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const $errorSummary = container.getByRole('alert')
+
+    const $heading = within($errorSummary).getByRole('heading', {
+      name: 'There is a problem',
+      level: 2
+    })
+
+    expect($heading).toBeInTheDocument()
+
+    const $errorItems = within($errorSummary).getAllByRole('listitem')
+    expect($errorItems[0]).toHaveTextContent(
+      'Select what is your business, Enrique Chase?'
+    )
+  })
+
+  test('POST /what-is-your-business', async () => {
+    const { response } = await renderResponse(server, {
+      url: `${basePath}/what-is-your-business`,
+      method: 'POST',
+      headers,
+      payload: { sdFYHf: 'grower', crumb: csrfToken }
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(response.headers.location).toBe(`${basePath}/information`)
+  })
+
+  test('GET /information', async () => {
+    const { container, response } = await renderResponse(server, {
+      url: `${basePath}/information`,
+      headers
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const $title = await container.findByText(
+      'Information: In England? true? - Templates - GOV.UK'
+    )
+
+    expect($title).toBeInTheDocument()
+
+    const $heading = container.getByRole('heading', {
+      name: 'Information: In England? true?',
+      level: 1
+    })
+
+    expect($heading).toBeInTheDocument()
+
+    const $output1 = container.getByTestId('output-1')
+    expect($output1).toBeInTheDocument()
+    expect($output1.textContent).toBe('Are you in England, Enrique Chase?')
+
+    const $output2 = container.getByTestId('output-2')
+    expect($output2).toBeInTheDocument()
+    expect($output2.textContent).toBe(
+      'A grower or producer of agricultural or horticultural produce'
+    )
+
+    const $output3 = container.getByTestId('output-3')
+    expect($output3).toBeInTheDocument()
+    expect($output3.textContent).toBe('Yes')
+
+    const $output4 = container.getByTestId('output-4')
+    expect($output4).toBeInTheDocument()
+    expect($output4.textContent).toBe('/templates/are-you-in-england')
+  })
+})
+
+/**
+ * @import { Server } from '@hapi/hapi'
+ */

--- a/test/form/template.test.js
+++ b/test/form/template.test.js
@@ -252,6 +252,35 @@ describe('Form template journey', () => {
     expect($output4).toBeInTheDocument()
     expect($output4.textContent).toBe('/templates/are-you-in-england')
   })
+
+  test('POST /information', async () => {
+    const { response } = await renderResponse(server, {
+      url: `${basePath}/information`,
+      method: 'POST',
+      headers,
+      payload: { crumb: csrfToken }
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(response.headers.location).toBe(`${basePath}/summary`)
+  })
+
+  test('GET /summary', async () => {
+    const { container, response } = await renderResponse(server, {
+      url: `${basePath}/summary`,
+      headers
+    })
+
+    expect(response.statusCode).toBe(StatusCodes.OK)
+
+    const $titles = container.queryAllByRole('term')
+    expect($titles).toHaveLength(3)
+    expect($titles[0]).toHaveTextContent("What's your full name?")
+    expect($titles[1]).toHaveTextContent('Are you in England, Enrique Chase?')
+    expect($titles[2]).toHaveTextContent(
+      'What is your business, Enrique Chase?'
+    )
+  })
 })
 
 /**


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/506180

## Templates

The following elements now support [LiquidJS templates](https://liquidjs.com/):

- Page **title**
- Form component **titles**
  - Support for fieldset legend text or label text
  - This includes when the title is used in **error messages**
- Html (guidance) component **content**
- Summary component **row** key title (check answers and repeater summary)

### Liquid Filters

There are a number of `LiquidJS` filters available from within the templates:

- `page` - returns the page definition for the given path
- `field` - returns the component definition for the given name
- `href` - returns the page href for the given page path
- `answer` - returns the user's answer for a given component
- `evaluate` - evaluates and returns a Liquid template using the current context
