### PR TITLE
Navigation to confirmation page

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,11 @@ import Boom from '@hapi/boom'
 
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
-import ConfirmationPageController from '~/src/server/controllers/confirmation-page.js'
 import DeclarationPageController from '~/src/server/controllers/declaration-page.js'
 import LandGrantsController from '~/src/server/controllers/land-grants.js'
 import ScorePageController from '~/src/server/controllers/score-page.js'
+// eslint-disable-next-line import/order
+import ConfirmationPageController from '~/src/server/controllers/confirmation-page.js'
 import { createServer } from '~/src/server/index.js'
 import { getForm } from '~/src/server/plugins/engine/configureEnginePlugin.js'
 import { engine } from '~/src/server/plugins/engine/helpers.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import Boom from '@hapi/boom'
 
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
+import ConfirmationPageController from '~/src/server/controllers/confirmation-page.js'
 import DeclarationPageController from '~/src/server/controllers/declaration-page.js'
 import LandGrantsController from '~/src/server/controllers/land-grants.js'
 import ScorePageController from '~/src/server/controllers/score-page.js'
@@ -237,7 +238,8 @@ async function startServer() {
     controllers: {
       LandGrantsController,
       ScorePageController,
-      DeclarationPageController
+      DeclarationPageController,
+      ConfirmationPageController
     }
   })
 

--- a/src/server/controllers/confirmation-page.js
+++ b/src/server/controllers/confirmation-page.js
@@ -30,6 +30,10 @@ export default class ConfirmationPageController extends StatusPageController {
     return fn
   }
 
+  /**
+   * Gets the path to the status page (in this case /confirmation page) for the GET handler.
+   * @returns {string} path to the status page
+   */
   getStatusPath() {
     return '/confirmation'
   }

--- a/src/server/controllers/confirmation-page.js
+++ b/src/server/controllers/confirmation-page.js
@@ -1,7 +1,42 @@
 import { StatusPageController } from '~/src/server/plugins/engine/pageControllers/StatusPageController.js'
 
 export default class ConfirmationPageController extends StatusPageController {
+  viewName = 'grants/confirmation'
+
+  /**
+   * This method is called when there is a GET request to the confirmation page.
+   * The method then uses the `h.view` method to render the page using the
+   * view name and the view model.
+   */
+  makeGetRouteHandler() {
+    /**
+     * Handle GET requests to the score page.
+     * @param {FormRequest} request
+     * @param {FormContext} context
+     * @param {Pick<ResponseToolkit, 'redirect' | 'view'>} h
+     */
+    // eslint-disable-next-line @typescript-eslint/require-await
+    const fn = async (request, context, h) => {
+      const { collection, viewName } = this
+
+      const viewModel = {
+        ...super.getViewModel(request, context),
+        errors: collection.getErrors(collection.getErrors()),
+        referenceNumber: 'AV-EA9-942'
+      }
+      return h.view(viewName, viewModel)
+    }
+
+    return fn
+  }
+
   getStatusPath() {
     return '/confirmation'
   }
 }
+
+/**
+ * @import { type FormRequest } from '~/src/server/routes/types.js'
+ * @import { type FormContext } from '~/src/server/plugins/engine/types.js'
+ * @import { type ResponseToolkit } from '@hapi/hapi'
+ */

--- a/src/server/controllers/confirmation-page.js
+++ b/src/server/controllers/confirmation-page.js
@@ -1,0 +1,7 @@
+import { StatusPageController } from '~/src/server/plugins/engine/pageControllers/StatusPageController.js'
+
+export default class ConfirmationPageController extends StatusPageController {
+  getStatusPath() {
+    return '/confirmation'
+  }
+}

--- a/src/server/controllers/declaration-page.js
+++ b/src/server/controllers/declaration-page.js
@@ -9,6 +9,10 @@ export default class DeclarationPageController extends SummaryPageController {
     super(model, pageDef)
     this.viewName = 'grants/declaration'
   }
+
+  getStatusPath() {
+    return '/confirmation'
+  }
 }
 
 /**

--- a/src/server/controllers/declaration-page.js
+++ b/src/server/controllers/declaration-page.js
@@ -10,6 +10,10 @@ export default class DeclarationPageController extends SummaryPageController {
     this.viewName = 'grants/declaration'
   }
 
+  /**
+   * Gets the path to the status page (in this case /confirmation page) for the POST handler.
+   * @returns {string} path to the status page
+   */
   getStatusPath() {
     return '/confirmation'
   }

--- a/src/server/forms/adding-value.json
+++ b/src/server/forms/adding-value.json
@@ -602,6 +602,7 @@
     {
       "title": "Confirmation",
       "path": "/confirmation",
+      "controller": "ConfirmationPageController",
       "next": [],
       "components": []
     },

--- a/src/server/forms/adding-value.json
+++ b/src/server/forms/adding-value.json
@@ -605,11 +605,6 @@
       "controller": "ConfirmationPageController",
       "next": [],
       "components": []
-    },
-    {
-      "path": "/summary",
-      "controller": "SummaryPageController",
-      "title": "Check your answers before submitting your form"
     }
   ],
   "lists": [

--- a/src/server/views/grants/confirmation.html
+++ b/src/server/views/grants/confirmation.html
@@ -1,0 +1,16 @@
+{% extends "layout.html" %}
+
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({
+        titleText: "Details submitted",
+        html: ("Your reference number<br><strong>" + referenceNumber + "</strong>") | safe
+      }) }}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This PR aims at providing the navigation needed for @swdpcomputing to link the #76 with the confirmation page he is working on.

It creates the placeholder `grants/confirmation.html` (that will become the page Stephen is working on as per above) page and adds `ConfirmationPageController` that links to the correct view and provides correct navigation links.