### PR TITLE
Revert to calling Scoring Service directly

### DIFF
--- a/src/server/forms/adding-value.json
+++ b/src/server/forms/adding-value.json
@@ -299,7 +299,7 @@
           "type": "http",
           "options": {
             "method": "POST",
-            "url": "https://fg-gas-backend.cdpEnvironment.cdp-int.defra.cloud/grants/adding-value/actions/calculate-score/invoke"
+            "url": "https://ffc-grants-scoring.cdpEnvironment.cdp-int.defra.cloud/scoring/api/v1/adding-value/score?allowPartialScoring=true"
           }
         }
       }


### PR DESCRIPTION
Decision has been taken to bypass GAS for calls to the Scoring Service. This PR reverts to the direct URL.