### PR TITLE
Add county as optional field to UkAddressField component

### DIFF
--- a/src/server/forms/adding-value.json
+++ b/src/server/forms/adding-value.json
@@ -445,85 +445,19 @@
         },
         {
           "type": "Html",
-          "name": "agentBusinessAddress",
+          "name": "agentBusinessAddressHeader",
           "title": "Html",
           "content": "<h1 class=\"govuk-heading-m\">Business address</h1>",
           "options": {},
           "schema": {}
         },
         {
-          "type": "TextField",
-          "name": "agentAddressLineOne",
-          "title": "Address line 1",
-          "options": {
-            "required": true,
-            "customValidationMessages": {
-              "string.empty": "Enter your address line 1",
-              "string.min": "Address must include at least 3 letters",
-              "string.pattern.base": "Address must only include letters, numbers, hyphens and apostrophes"
-            }
-          },
-          "schema": {
-            "regex": "^[a-zA-Z0-9' -]*$",
-            "min": 3
-          }
-        },
-        {
-          "type": "TextField",
-          "name": "agentAddressLineTwo",
-          "title": "Address line 2",
-          "options": {
-            "required": false,
-            "customValidationMessages": {
-              "string.min": "Address must include at least 3 letters",
-              "string.pattern.base": "Address must only include letters, numbers, hyphens and apostrophes"
-            }
-          },
-          "schema": {
-            "regex": "^[a-zA-Z0-9' -]*$",
-            "min": 3
-          }
-        },
-        {
-          "type": "TextField",
-          "name": "agentTown",
-          "title": "Town",
-          "options": {
-            "required": true,
-            "customValidationMessages": {
-              "string.empty": "Enter your town",
-              "string.min": "Town must include letters",
-              "string.pattern.base": "Town must only include letters, hyphens and spaces"
-            }
-          },
-          "schema": {
-            "regex": "^[a-zA-Z\\s-]+$",
-            "min": 2
-          }
-        },
-        {
-          "type": "TextField",
-          "name": "agentCounty",
-          "title": "County",
-          "options": {
-            "required": false
-          },
+          "type": "UkAddressField",
+          "title": "Address",
+          "name": "agentBusinessAddress",
+          "hint": "",
+          "options": {},
           "schema": {}
-        },
-        {
-          "type": "TextField",
-          "name": "agentPostcode",
-          "title": "Postcode",
-          "options": {
-            "required": true,
-            "customValidationMessages": {
-              "string.empty": "Enter your postcode, like AA1 1AA",
-              "string.pattern.base": "Enter a postcode, like AA1 1AA"
-            }
-          },
-          "schema": {
-            "regex": "^[a-zA-Z]{1,2}\\d[a-zA-Z\\d]?\\s?\\d[a-zA-Z]{2}$"
-          }
         }
       ],
       "condition": "agentDetailsSelected"
@@ -635,85 +569,19 @@
         },
         {
           "type": "Html",
-          "name": "applicantBusinessAddress",
+          "name": "applicantBusinessAddressHeader",
           "title": "Html",
           "content": "<h1 class=\"govuk-heading-m\">Business address</h1>",
           "options": {},
           "schema": {}
         },
         {
-          "type": "TextField",
-          "name": "applicantAddressLineOne",
-          "title": "Address line 1",
-          "options": {
-            "required": true,
-            "customValidationMessages": {
-              "string.empty": "Enter your address line 1",
-              "string.min": "Address must include at least 3 letters",
-              "string.pattern.base": "Address must only include letters, numbers, hyphens and apostrophes"
-            }
-          },
-          "schema": {
-            "regex": "^[a-zA-Z0-9' -]*$",
-            "min": 3
-          }
-        },
-        {
-          "type": "TextField",
-          "name": "applicantAddressLineTwo",
-          "title": "Address line 2",
-          "options": {
-            "required": false,
-            "customValidationMessages": {
-              "string.min": "Address must include at least 3 letters",
-              "string.pattern.base": "Address must only include letters, numbers, hyphens and apostrophes"
-            }
-          },
-          "schema": {
-            "regex": "^[a-zA-Z0-9' -]*$",
-            "min": 3
-          }
-        },
-        {
-          "type": "TextField",
-          "name": "applicantTown",
-          "title": "Town",
-          "options": {
-            "required": true,
-            "customValidationMessages": {
-              "string.empty": "Enter your town",
-              "string.min": "Town must include letters",
-              "string.pattern.base": "Town must only include letters, hyphens and spaces"
-            }
-          },
-          "schema": {
-            "regex": "^[a-zA-Z\\s-]+$",
-            "min": 2
-          }
-        },
-        {
-          "type": "TextField",
-          "name": "applicantCounty",
-          "title": "County",
-          "options": {
-            "required": false
-          },
+          "type": "UkAddressField",
+          "title": "Address",
+          "name": "applicantBusinessAddress",
+          "hint": "",
+          "options": {},
           "schema": {}
-        },
-        {
-          "type": "TextField",
-          "name": "applicantBusinessPostcode",
-          "title": "Business postcode",
-          "options": {
-            "required": true,
-            "customValidationMessages": {
-              "string.empty": "Enter your postcode, like AA1 1AA",
-              "string.pattern.base": "Enter a postcode, like AA1 1AA"
-            }
-          },
-          "schema": {
-            "regex": "^[a-zA-Z]{1,2}\\d[a-zA-Z\\d]?\\s?\\d[a-zA-Z]{2}$"
-          }
         },
         {
           "type": "TextField",
@@ -723,8 +591,8 @@
           "options": {
             "required": true,
             "customValidationMessages": {
-              "string.empty": "Enter your postcode, like AA1 1AA",
-              "string.pattern.base": "Enter a postcode, like AA1 1AA"
+              "string.empty": "Enter postcode",
+              "string.pattern.base": "Enter a valid postcode"
             }
           },
           "schema": {

--- a/src/server/plugins/engine/components/UkAddressField.test.ts
+++ b/src/server/plugins/engine/components/UkAddressField.test.ts
@@ -66,6 +66,13 @@ describe('UkAddressField', () => {
         )
 
         expect(keys).toHaveProperty(
+          'myComponent__county',
+          expect.objectContaining({
+            flags: expect.objectContaining({ label: 'County' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
           `myComponent__postcode`,
           expect.objectContaining({
             flags: expect.objectContaining({ label: 'Postcode' })
@@ -82,6 +89,7 @@ describe('UkAddressField', () => {
           'myComponent__addressLine1',
           'myComponent__addressLine2',
           'myComponent__town',
+          'myComponent__county',
           'myComponent__postcode'
         ])
 
@@ -114,6 +122,14 @@ describe('UkAddressField', () => {
         expect(keys).toHaveProperty(
           'myComponent__town',
           expect.objectContaining({
+            flags: expect.objectContaining({ presence: 'required' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__county',
+          expect.objectContaining({
+            allow: [''], // Required but empty string is allowed
             flags: expect.objectContaining({ presence: 'required' })
           })
         )
@@ -158,6 +174,11 @@ describe('UkAddressField', () => {
         )
 
         expect(keys).toHaveProperty(
+          'myComponent__county',
+          expect.objectContaining({ allow: [''] })
+        )
+
+        expect(keys).toHaveProperty(
           `myComponent__postcode`,
           expect.objectContaining({ allow: [''] })
         )
@@ -167,6 +188,7 @@ describe('UkAddressField', () => {
             addressLine1: '',
             addressLine2: '',
             town: '',
+            county: '',
             postcode: ''
           })
         )
@@ -180,6 +202,7 @@ describe('UkAddressField', () => {
             addressLine1: 'Richard Fairclough House',
             addressLine2: 'Knutsford Road',
             town: 'Warrington',
+            county: 'Cheshire',
             postcode: 'WA4 1HT'
           })
         )
@@ -189,6 +212,7 @@ describe('UkAddressField', () => {
             addressLine1: 'Richard Fairclough House',
             addressLine2: '', // Optional field
             town: 'Warrington',
+            county: '', // Optional field
             postcode: 'WA4 1HT'
           })
         )
@@ -203,6 +227,7 @@ describe('UkAddressField', () => {
             addressLine1: '',
             addressLine2: '',
             town: '',
+            county: '',
             postcode: ''
           })
         )
@@ -228,6 +253,7 @@ describe('UkAddressField', () => {
             addressLine1: ['invalid'],
             addressLine2: ['invalid'],
             town: ['invalid'],
+            county: ['invalid'],
             postcode: ['invalid']
           })
         )
@@ -237,6 +263,7 @@ describe('UkAddressField', () => {
             addressLine1: 'invalid',
             addressLine2: 'invalid',
             town: 'invalid',
+            county: 'invalid',
             postcode: 'invalid'
           })
         )
@@ -252,6 +279,7 @@ describe('UkAddressField', () => {
         addressLine1: 'Richard Fairclough House',
         addressLine2: 'Knutsford Road',
         town: 'Warrington',
+        county: 'Cheshire',
         postcode: 'WA4 1HT'
       }
 
@@ -263,7 +291,7 @@ describe('UkAddressField', () => {
         const answer2 = getAnswer(field, state2)
 
         expect(answer1).toBe(
-          'Richard Fairclough House<br>Knutsford Road<br>Warrington<br>WA4 1HT<br>'
+          'Richard Fairclough House<br>Knutsford Road<br>Warrington<br>Cheshire<br>WA4 1HT<br>'
         )
 
         expect(answer2).toBe('')
@@ -302,6 +330,7 @@ describe('UkAddressField', () => {
           'Richard Fairclough House',
           'Knutsford Road',
           'Warrington',
+          'Cheshire',
           'WA4 1HT'
         ])
 
@@ -325,6 +354,7 @@ describe('UkAddressField', () => {
         addressLine1: 'Richard Fairclough House',
         addressLine2: 'Knutsford Road',
         town: 'Warrington',
+        county: 'Cheshire',
         postcode: 'WA4 1HT'
       }
 
@@ -364,6 +394,14 @@ describe('UkAddressField', () => {
               }),
 
               expect.objectContaining({
+                model: getViewModel(address, 'county', {
+                  label: { text: 'County (optional)' },
+                  attributes: { autocomplete: 'county' },
+                  value: address.county
+                })
+              }),
+
+              expect.objectContaining({
                 model: getViewModel(address, 'postcode', {
                   label: { text: 'Postcode' },
                   classes: 'govuk-input--width-10',
@@ -395,6 +433,7 @@ describe('UkAddressField', () => {
       addressLine1: 'Richard Fairclough House',
       addressLine2: 'Knutsford Road',
       town: 'Warrington',
+      county: 'Cheshire',
       postcode: 'WA4 1HT'
     }
 
@@ -406,6 +445,9 @@ describe('UkAddressField', () => {
 
     const townInvalid =
       'Town 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+
+    const countyInvalid =
+      'County 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
 
     const postcodeInvalid = '111 XX2'
 
@@ -424,6 +466,7 @@ describe('UkAddressField', () => {
               addressLine1: ' Richard Fairclough House',
               addressLine2: ' Knutsford Road',
               town: ' Warrington',
+              county: 'Cheshire',
               postcode: ' WA4 1HT'
             }),
             output: {
@@ -435,6 +478,7 @@ describe('UkAddressField', () => {
               addressLine1: 'Richard Fairclough House ',
               addressLine2: 'Knutsford Road ',
               town: 'Warrington ',
+              county: 'Cheshire ',
               postcode: 'WA4 1HT '
             }),
             output: {
@@ -446,6 +490,7 @@ describe('UkAddressField', () => {
               addressLine1: ' Richard Fairclough House \n\n',
               addressLine2: ' Knutsford Road \n\n',
               town: ' Warrington \n\n',
+              county: ' Cheshire \n\n',
               postcode: ' WA4 1HT \n\n'
             }),
             output: {
@@ -468,6 +513,7 @@ describe('UkAddressField', () => {
               addressLine1: addressLine1Invalid,
               addressLine2: 'Knutsford Road',
               town: 'Warrington',
+              county: 'Cheshire',
               postcode: 'WA4 1HT'
             }),
             output: {
@@ -475,6 +521,7 @@ describe('UkAddressField', () => {
                 addressLine1: addressLine1Invalid,
                 addressLine2: 'Knutsford Road',
                 town: 'Warrington',
+                county: 'Cheshire',
                 postcode: 'WA4 1HT'
               }),
               errors: [
@@ -489,6 +536,7 @@ describe('UkAddressField', () => {
               addressLine1: 'Richard Fairclough House',
               addressLine2: addressLine2Invalid,
               town: 'Warrington',
+              county: 'Cheshire',
               postcode: 'WA4 1HT'
             }),
             output: {
@@ -496,6 +544,7 @@ describe('UkAddressField', () => {
                 addressLine1: 'Richard Fairclough House',
                 addressLine2: addressLine2Invalid,
                 town: 'Warrington',
+                county: 'Cheshire',
                 postcode: 'WA4 1HT'
               }),
               errors: [
@@ -510,6 +559,7 @@ describe('UkAddressField', () => {
               addressLine1: 'Richard Fairclough House',
               addressLine2: 'Knutsford Road',
               town: townInvalid,
+              county: 'Cheshire',
               postcode: 'WA4 1HT'
             }),
             output: {
@@ -517,6 +567,7 @@ describe('UkAddressField', () => {
                 addressLine1: 'Richard Fairclough House',
                 addressLine2: 'Knutsford Road',
                 town: townInvalid,
+                county: 'Cheshire',
                 postcode: 'WA4 1HT'
               }),
               errors: [
@@ -531,6 +582,30 @@ describe('UkAddressField', () => {
               addressLine1: 'Richard Fairclough House',
               addressLine2: 'Knutsford Road',
               town: 'Warrington',
+              county: countyInvalid,
+              postcode: 'WA4 1HT'
+            }),
+            output: {
+              value: getFormData({
+                addressLine1: 'Richard Fairclough House',
+                addressLine2: 'Knutsford Road',
+                town: 'Warrington',
+                county: countyInvalid,
+                postcode: 'WA4 1HT'
+              }),
+              errors: [
+                expect.objectContaining({
+                  text: 'County must be 100 characters or less'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData({
+              addressLine1: 'Richard Fairclough House',
+              addressLine2: 'Knutsford Road',
+              town: 'Warrington',
+              county: 'Cheshire',
               postcode: postcodeInvalid
             }),
             output: {
@@ -538,6 +613,7 @@ describe('UkAddressField', () => {
                 addressLine1: 'Richard Fairclough House',
                 addressLine2: 'Knutsford Road',
                 town: 'Warrington',
+                county: 'Cheshire',
                 postcode: postcodeInvalid
               }),
               errors: [
@@ -602,6 +678,7 @@ function getFormData(address: FormPayload): FormPayload {
     myComponent__addressLine1: address.addressLine1,
     myComponent__addressLine2: address.addressLine2,
     myComponent__town: address.town,
+    myComponent__county: address.county,
     myComponent__postcode: address.postcode
   }
 }
@@ -610,7 +687,7 @@ function getFormData(address: FormPayload): FormPayload {
  * UK address session state
  */
 function getFormState(address: FormPayload): FormState {
-  const [addressLine1, addressLine2, town, postcode] = Object.values(
+  const [addressLine1, addressLine2, town, county, postcode] = Object.values(
     getFormData(address)
   )
 
@@ -618,6 +695,7 @@ function getFormState(address: FormPayload): FormState {
     myComponent__addressLine1: addressLine1 ?? null,
     myComponent__addressLine2: addressLine2 ?? null,
     myComponent__town: town ?? null,
+    myComponent__county: county ?? null,
     myComponent__postcode: postcode ?? null
   }
 }

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -170,8 +170,7 @@ export class UkAddressField extends FormComponent {
       isFormState(value) &&
       TextField.isText(value.addressLine1) &&
       TextField.isText(value.town) &&
-      TextField.isText(value.postcode) &&
-      (value.county === undefined || TextField.isText(value.county))
+      TextField.isText(value.postcode)
     )
   }
 }

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -72,6 +72,17 @@ export class UkAddressField extends FormComponent {
         },
         {
           type: ComponentType.TextField,
+          name: `${name}__county`,
+          title: 'County',
+          schema: { max: 100 },
+          options: {
+            autocomplete: 'county',
+            required: false,
+            optionalText: !isRequired && (hideOptional || !hideTitle)
+          }
+        },
+        {
+          type: ComponentType.TextField,
           name: `${name}__postcode`,
           title: 'Postcode',
           schema: {
@@ -159,7 +170,8 @@ export class UkAddressField extends FormComponent {
       isFormState(value) &&
       TextField.isText(value.addressLine1) &&
       TextField.isText(value.town) &&
-      TextField.isText(value.postcode)
+      TextField.isText(value.postcode) &&
+      (value.county === undefined || TextField.isText(value.county))
     )
   }
 }
@@ -168,5 +180,6 @@ export interface UkAddressState extends Record<string, string> {
   addressLine1: string
   addressLine2: string
   town: string
+  county: string
   postcode: string
 }

--- a/test/form/fields-optional.test.js
+++ b/test/form/fields-optional.test.js
@@ -93,6 +93,7 @@ describe('Form fields (optional)', () => {
               addressField__addressLine1: '',
               addressField__addressLine2: '',
               addressField__town: '',
+              addressField__county: '',
               addressField__postcode: ''
             }
           }

--- a/test/form/fields-required.test.js
+++ b/test/form/fields-required.test.js
@@ -109,12 +109,14 @@ describe('Form fields (required)', () => {
               addressField__addressLine1: '',
               addressField__addressLine2: '',
               addressField__town: '',
+              addressField__county: '',
               addressField__postcode: ''
             },
             valid: {
               addressField__addressLine1: 'Richard Fairclough House',
               addressField__addressLine2: 'Knutsford Road',
               addressField__town: 'Warrington',
+              addressField__county: 'Cheshire',
               addressField__postcode: 'WA4 1HT'
             }
           }

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -177,6 +177,7 @@ describe('Submission journey test', () => {
           Address line 1
           Address line 2
           Town or city
+          Cheshire
           CW1 1AB
 
           ---
@@ -283,7 +284,7 @@ describe('Submission journey test', () => {
         {
           name: 'addressField',
           title: 'Address field',
-          value: 'Address line 1,Address line 2,Town or city,CW1 1AB'
+          value: 'Address line 1,Address line 2,Town or city,Cheshire,CW1 1AB'
         },
         {
           name: 'radiosField',
@@ -354,6 +355,7 @@ describe('Submission journey test', () => {
       addressField__addressLine1: 'Address line 1',
       addressField__addressLine2: 'Address line 2',
       addressField__town: 'Town or city',
+      addressField__county: 'Cheshire',
       addressField__postcode: 'CW1 1AB',
       radiosField: 'privateLimitedCompany',
       selectField: '910400000',

--- a/test/form/titles.test.js
+++ b/test/form/titles.test.js
@@ -57,6 +57,7 @@ describe('Title and section title', () => {
           address1__addressLine1: 'Richard Fairclough House',
           address1__addressLine2: 'Knutsford Road',
           address1__town: 'Warrington',
+          address1__county: 'Cheshire',
           address1__postcode: 'WA4 1HT'
         }
       },
@@ -76,6 +77,7 @@ describe('Title and section title', () => {
           address2__addressLine1: '',
           address2__addressLine2: '',
           address2__town: '',
+          address2__county: '',
           address2__postcode: ''
         }
       }


### PR DESCRIPTION
![Screenshot 2025-03-25 at 16 49 40](https://github.com/user-attachments/assets/a49d0570-65e0-4d20-879c-3fabf357c511)

This PR updates the UkAddressField component to include an optional county field, aligning with DXT’s standard validation rules.

Changes
- Added a new county field to UkAddressField, with a max length of 100 characters.
- Implemented validation rules consistent with DXT standards.
- Updated the Project Postcode validation on the Applicant’s details page to ensure correct labeling and validation.
- Ensured that all address fields, including county, are correctly submitted and emailed.

New County subfield will follow this definition:

Field Label | Validation Rule | Error Message
-- | -- | --
County (Optional) | Max 100 chars (optional) | County must be 100 characters or less

The `Adding Value` Applicant's and Agent's Details pages will now use `UkAddressField` component instead of `TextField` for address fields. That will mean that the field labels will change for `Town` to `Town or city` and `Business Postcode` to just `Postcode`. The validation rules and error messages from previous solution will change as well from more specific like town is to follow `min 2 letters` or Address Line 1/2 to `min 3 letters` to more standard `not required` and `max 100 chars` rules from DXT solution.